### PR TITLE
add RH users into OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,10 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
 approvers:
-  - sig-cluster-lifecycle-leads
-  - cluster-api-admins
-  - cluster-api-maintainers
-  - cluster-api-azure-maintainers
+- jnpacker
+- marek-veber
+- mzazrivec
+- RadekCap
 
 reviewers:
-  - cluster-api-azure-maintainers
-  - cluster-api-azure-reviewers
-
-emeritus_approvers:
-  - alexeldeib
-  - awesomenix
-  - CecileRobertMichon
-  - justaugustus
-  - nader-ziada
-  - ncdc
-  - shysank
-  - sonasingh46
-  - devigned
+- marek-veber
+- mzazrivec
+- RadekCap


### PR DESCRIPTION
**What type of PR is this?**
Fix github users for RH

**What this PR does / why we need it**:
change OWNERS - RH approvers and reviewers