### PR TITLE
Add renovate.json to configure MintMaker dependency PRs (ARO-24895)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": [
+    "main",
+    "/^backplane-2\\.[0-99]$/"
+  ],
+  "tekton": {
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "schedule": [
+      "at any time"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "enabled": true,
+      "matchFileNames": [
+        "stolostron/Dockerfile.stolostron"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "main",
+        "/^backplane-2\\.[0-99]$/"
+      ],
+      "matchManagers": [
+        "tekton"
+      ],
+      "enabled": true,
+      "addLabels": [
+        "ok-to-test"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
+    }
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "never",
+  "addLabels": [
+    "ok-to-test"
+  ],
+  "schedule": [
+    "on monday"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `renovate.json` to control MintMaker (Konflux Renovate) behavior, stopping the flood of individual Go dependency PRs.

JIRA: https://issues.redhat.com/browse/ARO-24895

## Problem
MintMaker creates individual PRs for each Go dependency update, resulting in ~30 open PRs across `backplane-2.11` and `backplane-2.17` branches, making the PR list unmanageable.

## Solution
Add a `renovate.json` configuration (modeled after [stolostron/cluster-api-installer](https://github.com/stolostron/cluster-api-installer/blob/main/renovate.json)) that:
- **Disables** Go module (`gomod`) dependency updates
- **Keeps enabled** Dockerfile image updates for `stolostron/Dockerfile.stolostron` (base images: `registry.access.redhat.com/ubi8/go-toolset`, `registry.access.redhat.com/ubi9/ubi`)
- **Keeps enabled** Tekton pipeline updates (`.tekton/**`)
- Schedules updates weekly (Monday)
- Adds `ok-to-test` label to PRs
- Targets `main` and `backplane-2.*` branches

## Changes
- `renovate.json` — new file at repo root

## After merge
After this merges, MintMaker will stop creating Go dependency PRs on the next cycle (~4-8 hours). Existing ~30 open dependency PRs should be closed manually.

## Testing
- [x] Valid JSON
- [x] Configuration modeled after proven stolostron/cluster-api-installer setup

Ref: ARO-24895

Generated with [Claude Code](https://claude.com/claude-code)