### PR TITLE
Add renovate.json to configure MintMaker dependency PRs (ARO-24895)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": [
+    "main",
+    "/^backplane-2\\.[0-99]$/"
+  ],
+  "tekton": {
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "schedule": [
+      "at any time"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "enabled": true,
+      "matchFileNames": [
+        "stolostron/Dockerfile.stolostron"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "main",
+        "/^backplane-2\\.[0-99]$/"
+      ],
+      "matchManagers": [
+        "tekton"
+      ],
+      "enabled": true,
+      "addLabels": [
+        "ok-to-test"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
+    }
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "never",
+  "addLabels": [
+    "ok-to-test"
+  ],
+  "schedule": [
+    "on monday"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `renovate.json` to control MintMaker (Konflux Renovate) behavior, stopping the flood of individual Go dependency PRs.

JIRA: https://issues.redhat.com/browse/ARO-24895

## Problem
MintMaker creates individual PRs for each Go dependency update, making the PR list unmanageable.

## Solution
Add a `renovate.json` configuration (modeled after [stolostron/cluster-api-installer](https://github.com/stolostron/cluster-api-installer/blob/main/renovate.json)) that:
- **Disables** Go module (`gomod`) dependency updates
- **Keeps enabled** Dockerfile image updates for `stolostron/Dockerfile.stolostron`
- **Keeps enabled** Tekton pipeline updates (`.tekton/**`)
- Schedules updates weekly (Monday)
- Adds `ok-to-test` label to PRs

## Changes
- `renovate.json` — new file at repo root

Ref: ARO-24895

Generated with [Claude Code](https://claude.com/claude-code)