### PR TITLE
Rewrite weekly security scan with Trivy SARIF reporting

### DIFF
--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -251,7 +251,7 @@ jobs:
             echo "<summary><b>Trivy Findings</b></summary>"
             echo ""
             echo '```'
-            cat trivy-results.txt 2>/dev/null || echo "See workflow run logs for complete details"
+            cat trivy-results.txt 2>/dev/null | head -200 || echo "See workflow run logs for complete details"
             echo '```'
             echo ""
             echo "</details>"


### PR DESCRIPTION
## Summary
- Replaces bare `make verify-security` (govulncheck) with the Trivy action pattern from [capi-tests](https://github.com/stolostron/capi-tests/actions/workflows/security-trivy.yml)
- Uploads SARIF results to the **Security tab** — no more digging through raw logs
- Generates a **step summary** with severity breakdown visible in the Actions UI
- **Auto-creates GitHub issues** with vulnerability counts when findings are detected, and comments on existing issues instead of creating duplicates
- Stores scan results as **downloadable artifacts** (30-day retention)
- Adds `workflow_dispatch` trigger for manual runs
- Adds `timeout-minutes: 15` to prevent hung jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Security scan workflow now supports manual triggering, branch-aware context, and explicit token permissions.
  * Scans produce SARIF and human-readable reports; both are uploaded and retained as artifacts for 30 days; SARIF is submitted to code scanning (with failure warning).
  * Summary step always reports per-severity counts and totals and preserves outputs on error.
  * Non-PR failing runs can create or update a repository issue with vulnerability counts and truncated scan output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->