### PR TITLE
Add ARO-HCP team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,10 +5,16 @@ approvers:
   - cluster-api-admins
   - cluster-api-maintainers
   - cluster-api-azure-maintainers
+  - RadekCap
+  - marek-veber
+  - mzazrivec
 
 reviewers:
   - cluster-api-azure-maintainers
   - cluster-api-azure-reviewers
+  - RadekCap
+  - marek-veber
+  - mzazrivec
 
 emeritus_approvers:
   - alexeldeib


### PR DESCRIPTION
## Summary
- Add @RadekCap, @marek-veber, and @mzazrivec as approvers and reviewers in `OWNERS`
- Enables the ARO-HCP team to review and approve PRs on the main branch

## Test plan
- [ ] Verify the three users can approve and review PRs via Prow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this update. This release contains internal organizational updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->