### PR TITLE
ARO-25108: Add v1api20251223preview API support for HcpOpenShift resources

### DIFF
--- a/CHANGELOG/v1.22.1-mce-217.md
+++ b/CHANGELOG/v1.22.1-mce-217.md
@@ -1,0 +1,56 @@
+## Changes by Kind
+
+### Feature
+
+- **ARO HCP API v1api20251223preview support**: Full support for the new `2025-12-23-preview` ARM API version for HcpOpenShiftClusters, HcpOpenShiftClustersNodePools, and HcpOpenShiftClustersExternalAuth resources
+  - Both `v1api20240610preview` and `v1api20251223preview` API versions are supported simultaneously
+  - CAPZ auto-detects the API version used and handles structural differences (e.g., KMS `vaultName` field location)
+  - Updated ASO CRDs with `v1api20251223previewstorage` as the new storage version for HcpOpenShift resources
+
+### Bug Fixes
+
+- **ASO resource reconciliation conflict fix (ARO-25529)**: Stop continuously re-patching ASO resources that are already ready, preventing conflicts with ASO controllers (etcd commit failures and generation inflation)
+  - Skip resource reconciliation when all resources are ready and the spec hasn't changed
+  - Use `ObservedGeneration` on the `ResourcesReady` condition to detect spec changes
+  - Add `ASOReadyChangedPredicate` to watch for ASO Ready condition changes on managed resources
+  - Remove unnecessary `RequeueAfter` polling in favor of event-driven watches
+- **ExternalAuth deletion fix**: Fix ExternalAuth deletion when NodePool is in failed state
+- **KeyVault bombardment fix**: Add predicate to dynamic watches to prevent excessive KeyVault reconciliation
+- **AROMachinePool autoscaler fix**: Fix autoscaling and API version handling for AROMachinePool
+- **Encryption key readiness fix**: Properly defer HcpOpenShiftCluster apply until encryption key version is available, preventing CRD validation errors
+- **Graceful error handling**: Handle NotFound and NoMatch errors gracefully in AROMachinePool and AROControlPlane reconcilers
+
+### Dependencies
+
+- Updated ASO CRDs to include `v1api20251223preview` and `v1api20251223previewstorage` versions
+- Migrated HcpOpenShift resource storage version from `v1api20240610previewstorage` to `v1api20251223previewstorage`
+
+## API Changes (v1api20240610preview vs v1api20251223preview)
+
+### HcpOpenShiftCluster - KMS encryption structure
+
+**v1api20240610preview** (old):
+```yaml
+kms:
+  activeKey:
+    name: "key-name"
+    vaultName: "vault-name"    # vaultName inside activeKey
+    version: "key-version"
+```
+
+**v1api20251223preview** (new):
+```yaml
+kms:
+  activeKey:
+    name: "key-name"
+    version: "key-version"
+  vaultName: "vault-name"      # vaultName moved to kms level
+  visibility: "Public"         # new required field
+```
+
+## Details
+
+This release is based on upstream v1.22.0 with Red Hat MCE-specific additions for ARO-HCP support.
+
+Base upstream version: v1.22.0
+MCE version: 2.17

--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,8 @@ CRD_ROOT ?= $(MANIFEST_ROOT)/crd/bases
 WEBHOOK_ROOT ?= $(MANIFEST_ROOT)/webhook
 RBAC_ROOT ?= $(MANIFEST_ROOT)/rbac
 ASO_CRDS_PATH := $(MANIFEST_ROOT)/aso/crds.yaml
-ASO_VERSION := v2.13.0-hcpclusters.3
-ASO_WORKSPACE := marek-veber
+ASO_VERSION := v2.13.0-hcpclusters.7
+ASO_WORKSPACE := stolostron
 ASO_CRDS := resourcegroups.resources.azure.com natgateways.network.azure.com managedclusters.containerservice.azure.com managedclustersagentpools.containerservice.azure.com bastionhosts.network.azure.com virtualnetworks.network.azure.com virtualnetworkssubnets.network.azure.com privateendpoints.network.azure.com fleetsmembers.containerservice.azure.com extensions.kubernetesconfiguration.azure.com userassignedidentities.managedidentity.azure.com roleassignments.authorization.azure.com networksecuritygroups.network.azure.com vaults.keyvault.azure.com hcpopenshiftclusters.redhatopenshift.azure.com hcpopenshiftclustersnodepools.redhatopenshift.azure.com hcpopenshiftclustersexternalauths.redhatopenshift.azure.com
 
 # Allow overriding the imagePullPolicy


### PR DESCRIPTION
## Summary
- Update ASO CRDs to use `v1api20251223previewstorage` as the storage version for HcpOpenShiftClusters, HcpOpenShiftClustersNodePools, and HcpOpenShiftClustersExternalAuth
- This enables ASO to use the `2025-12-23-preview` ARM API version when communicating with Azure
- Add CHANGELOG for v1.22.1-mce-217 release

## Key Changes
- **CRD storage version migration**: `v1api20240610previewstorage` → `v1api20251223previewstorage` for all HcpOpenShift resources
- **KMS structure change**: In the new API, `vaultName` moved from `kms.activeKey.vaultName` to `kms.vaultName`, and a new required `visibility` field was added at the `kms` level
- **Makefile**: Updated ASO CRD generation to target the new API version

## Test plan
- [ ] Deploy updated CRDs and verify ASO conversion webhook handles version conversion
- [ ] Verify HcpOpenShiftCluster creation with `v1api20251223preview` API version
- [ ] Verify existing clusters using `v1api20240610preview` continue to work via conversion webhook
- [ ] Verify ETCD encryption key management with the new KMS structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)