### PR TITLE
ci: update weekly security scan branches

### DIFF
--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.21, release-1.20 ]
+        branch: [ main, release-1.21, release-1.22 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.21, release-1.22 ]
+        branch: [ backplane-2.11, backplane-2.17 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Replace `release-1.20` with `release-1.22` in the weekly security scan matrix
- `release-1.20` no longer exists, causing the Trivy scan job to fail on checkout

## Test plan
- [ ] Verify the weekly security scan workflow runs successfully on all three branches (`main`, `release-1.21`, `release-1.22`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated scheduled security scan configuration to target the current release branch versions used for verification.
  * No functional changes to job steps or behavior; scan schedule and controls remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->