### PR TITLE
Fix renovate.json branch pattern regex and add backplane-5 (ARO-24895)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranchPatterns": [
     "main",
-    "/^backplane-2\\.[0-99]$/"
+    "/^backplane-2\\.[0-9]+$/",
+    "/^backplane-5\\.[0-9]+$/"
   ],
   "tekton": {
     "includePaths": [
@@ -25,7 +26,8 @@
     {
       "matchBaseBranches": [
         "main",
-        "/^backplane-2\\.[0-99]$/"
+        "/^backplane-2\\.[0-9]+$/",
+        "/^backplane-5\\.[0-9]+$/"
       ],
       "matchManagers": [
         "tekton"


### PR DESCRIPTION
## Summary
- Fix `[0-99]` regex character class → `[0-9]+` to correctly match multi-digit branch numbers (e.g. `backplane-2.11`, `backplane-2.17`)
- Add `backplane-5` branch pattern to `baseBranchPatterns` and `matchBaseBranches`

The original `[0-99]` is a character class matching a single digit `0-9`, not the numeric range 0–99. This meant branches like `backplane-2.11` and `backplane-2.17` were not matched.

## Test plan
- [ ] Verify Renovate picks up the correct branches after merge
- [ ] Confirm no new unwanted gomod dependency PRs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)