### PR TITLE
ARO-25822 - backplane-2.17 - Bump base ubi9/ubi image to 9.7-1777525589 in Konflux images

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -26,6 +26,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-extldflags '-static'" -o ./manager .
 
 # Copy the aso-controller into a thin image
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1754380668
+FROM registry.access.redhat.com/ubi9/ubi:9.7-1777525589
 COPY --from=builder /workspace/manager /manager
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary
 * [ARO-25822](https://redhat.atlassian.net/browse/ARO-25822) - Bump base ubi9/ubi image to 9.7-1777525589 in Konflux images

[ARO-25822]: https://redhat.atlassian.net/browse/ARO-25822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ