### PR TITLE
Add Tekton files for versions: 5.0 5.1

### DIFF
--- a/.tekton/cluster-api-provider-azure-mce-50-pull-request.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-50-pull-request.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-azure?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "backplane-5.0"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-mce-50
+    appstudio.openshift.io/component: cluster-api-provider-azure-mce-50
+    pipelines.appstudio.openshift.io/type: build
+  name: cluster-api-provider-azure-mce-50-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-50:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: stolostron/Dockerfile.stolostron
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common_mce_2.11.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cluster-api-provider-azure-mce-50
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/cluster-api-provider-azure-mce-50-push.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-50-push.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-azure?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "backplane-5.0"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-mce-50
+    appstudio.openshift.io/component: cluster-api-provider-azure-mce-50
+    pipelines.appstudio.openshift.io/type: build
+  name: cluster-api-provider-azure-mce-50-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-50:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: dockerfile
+    value: stolostron/Dockerfile.stolostron
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: send-slack-notification
+    value: true
+  - name: konflux-application-name
+    value: release-mce-50
+  - name: slack-member-id
+    value: C07JR0ARW1E # capi-squad channel-id.
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common_mce_2.11.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cluster-api-provider-azure-mce-50
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/cluster-api-provider-azure-mce-51-pull-request.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-51-pull-request.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-azure?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "backplane-5.1"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-mce-51
+    appstudio.openshift.io/component: cluster-api-provider-azure-mce-51
+    pipelines.appstudio.openshift.io/type: build
+  name: cluster-api-provider-azure-mce-51-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-51:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: stolostron/Dockerfile.stolostron
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common_mce_2.11.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cluster-api-provider-azure-mce-51
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/cluster-api-provider-azure-mce-51-push.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-51-push.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-azure?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "backplane-5.1"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: release-mce-51
+    appstudio.openshift.io/component: cluster-api-provider-azure-mce-51
+    pipelines.appstudio.openshift.io/type: build
+  name: cluster-api-provider-azure-mce-51-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-51:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: dockerfile
+    value: stolostron/Dockerfile.stolostron
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: send-slack-notification
+    value: true
+  - name: konflux-application-name
+    value: release-mce-51
+  - name: slack-member-id
+    value: C07JR0ARW1E # capi-squad channel-id.
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/stolostron/konflux-build-catalog.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common_mce_2.11.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cluster-api-provider-azure-mce-51
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
This PR adds Tekton pipeline files for the following versions:
- mce-50
- mce-51

Generated from existing mce-217 templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added new automated pipeline configurations supporting multiple cloud platform variants and deployment environments
  * Enhanced continuous integration and pull request validation workflows with improved automated build and testing capabilities
  * Implemented notification systems for automated build status alerts and team communication
  * Configured workspace and authentication improvements for reliable pipeline execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->