### PR TITLE
fix: use enabledManagers whitelist to stop Konflux gomod PR spam

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "tekton",
+    "dockerfile"
+  ],
   "baseBranchPatterns": [
     "main",
     "/^backplane-2\\.[0-9]+$/",
@@ -36,12 +40,6 @@
       "addLabels": [
         "ok-to-test"
       ]
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false
     }
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Summary
- Add `enabledManagers` whitelist (`tekton`, `dockerfile`) to override MintMaker's global config
- Remove ineffective `packageRules`-based gomod disable that cannot override top-level manager enablement
- Same fix approach as openshift/agent-installer-utils PR #163 (OCPBUGS-61956)

Ref: ARO-26785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to explicitly enable dependency management for Tekton pipeline and Dockerfile formats, improving automated update detection for these file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->