### PR TITLE
[backplane-5.1] fix: use enabledManagers whitelist to stop Konflux gomod PR spam

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "tekton",
+    "dockerfile"
+  ],
   "baseBranchPatterns": [
     "main",
     "/^backplane-2\\.[0-9]+$/",
@@ -36,12 +40,6 @@
       "addLabels": [
         "ok-to-test"
       ]
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "enabled": false
     }
   ],
   "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Summary
- Cherry-pick of #220 to `backplane-5.1`
- Add `enabledManagers` whitelist (`tekton`, `dockerfile`) to override MintMaker's global config
- Remove ineffective `packageRules`-based gomod disable that cannot override top-level manager enablement

Ref: ARO-26785

🤖 Generated with [Claude Code](https://claude.com/claude-code)