### PR TITLE
fix: restrict Renovate dockerfile updates to stolostron/Dockerfile.stolostron

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
       "enabled": true,
       "matchFileNames": [
         "stolostron/Dockerfile.stolostron"


### PR DESCRIPTION
## Summary
- Add a `enabled: false` packageRule for all dockerfile updates, followed by an enable rule scoped to `stolostron/Dockerfile.stolostron` only
- Prevents MintMaker from creating PRs for the root `Dockerfile` and any other Dockerfiles in the repo
- Follows up on PR #220 which introduced the `enabledManagers` whitelist but didn't restrict dockerfile scope

Ref: ARO-26785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to disable Dockerfile package updates for specified paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->