### PR TITLE
fix: restrict Renovate dockerfile updates to stolostron/Dockerfile.stolostron

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
       "matchManagers": [
         "dockerfile"
       ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
       "enabled": true,
       "matchFileNames": [
         "stolostron/Dockerfile.stolostron"


### PR DESCRIPTION
## Summary
- Add an `enabled: false` packageRule for all dockerfile updates, followed by an enable rule scoped to `stolostron/Dockerfile.stolostron` only
- Prevents MintMaker from creating PRs for the root `Dockerfile` and any other Dockerfiles in the repo
- Backport of PR #226 to backplane-2.17

Ref: ARO-26785

🤖 Generated with [Claude Code](https://claude.com/claude-code)