### PR TITLE
ARO-26909: Add renovate.json to main without backplane-5.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
   ],
   "baseBranchPatterns": [
     "main",
-    "/^backplane-2\\.[0-9]+$/",
-    "/^backplane-5\\.[0-9]+$/"
+    "/^backplane-2\\.[0-9]+$/"
   ],
   "tekton": {
     "includePaths": [
@@ -36,8 +35,7 @@
     {
       "matchBaseBranches": [
         "main",
-        "/^backplane-2\\.[0-9]+$/",
-        "/^backplane-5\\.[0-9]+$/"
+        "/^backplane-2\\.[0-9]+$/"
       ],
       "matchManagers": [
         "tekton"


### PR DESCRIPTION
## Summary
- Add `renovate.json` to `main` — Renovate reads config only from the default branch, so this is the authoritative location
- Exclude `backplane-5.x` branches from `baseBranchPatterns` — dependency updates for 5.x are handled via fast-forward sync from main (e.g. #237 was redundant)

## Test plan
- [ ] Verify Renovate no longer creates PRs against `backplane-5.x` branches
- [ ] Confirm Renovate still targets `main` and `backplane-2.x` branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to adjust base-branch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->