### PR TITLE
ARO-26765: Use baseDomainPrefix for node label matching

### DIFF
--- a/exp/controllers/aromachinepool_providerid_test.go
+++ b/exp/controllers/aromachinepool_providerid_test.go
@@ -307,6 +307,137 @@ func TestProviderIDListSync_AzureNameDiffersFromK8sName(t *testing.T) {
 	g.Expect(aroMachinePool.Spec.ProviderIDList).To(ContainElement(nodes[1].Spec.ProviderID))
 }
 
+// TestProviderIDListSync_BaseDomainPrefixDiffersFromCAPIName tests the case where
+// HcpOpenShiftCluster.status.properties.dns.baseDomainPrefix differs from the
+// CAPI cluster name. The node label uses the baseDomainPrefix, so we must read
+// it from the HcpOpenShiftCluster on the management cluster.
+func TestProviderIDListSync_BaseDomainPrefixDiffersFromCAPIName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const (
+		clusterName       = "ethos700-dev-va7"
+		namespace         = "ethos700-dev-va7"
+		nodePoolName      = "ethos700-dev-va7-watsonxcomp-1"
+		azureName         = "watsonxcomp1"
+		baseDomainPrefix  = "f4k6p2z2p0z9b3a" // differs from CAPI cluster name
+		subscriptionID    = "00000000-0000-0000-0000-000000000000"
+		resourceGroupName = "ethos_700_dev_va7"
+	)
+
+	// Nodes use baseDomainPrefix in labels, NOT the CAPI cluster name
+	nodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   baseDomainPrefix + "-" + azureName + "-wpcr6-95pzn",
+				Labels: expectedNodeLabels(baseDomainPrefix + "-" + azureName),
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/" + baseDomainPrefix + "-" + azureName + "-wpcr6-95pzn",
+			},
+		},
+	}
+
+	managedClusterScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(managedClusterScheme)
+	managedClusterClient := fake.NewClientBuilder().
+		WithScheme(managedClusterScheme).
+		WithObjects(&nodes[0]).
+		Build()
+
+	nodePool := &asoredhatopenshiftv1.HcpOpenShiftClustersNodePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HcpOpenShiftClustersNodePool",
+			APIVersion: asoredhatopenshiftv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodePoolName,
+			Namespace: namespace,
+		},
+		Spec: asoredhatopenshiftv1.HcpOpenShiftClustersNodePool_Spec{
+			AzureName: azureName,
+			Owner: &genruntime.KnownResourceReference{
+				Name: clusterName,
+			},
+		},
+		Status: asoredhatopenshiftv1.HcpOpenShiftClustersNodePool_STATUS{
+			Properties: &asoredhatopenshiftv1.NodePoolProperties_STATUS{
+				Replicas: ptr.To(1),
+			},
+		},
+	}
+
+	// HcpOpenShiftCluster on the management cluster with baseDomainPrefix in status
+	hcpCluster := &asoredhatopenshiftv1.HcpOpenShiftCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Status: asoredhatopenshiftv1.HcpOpenShiftCluster_STATUS{
+			Properties: &asoredhatopenshiftv1.HcpOpenShiftClusterProperties_STATUS{
+				Dns: &asoredhatopenshiftv1.DnsProfile_STATUS{
+					BaseDomainPrefix: ptr.To(baseDomainPrefix),
+				},
+			},
+		},
+	}
+
+	aroMachinePool := createTestAROMachinePool(namespace, nodePoolName, clusterName, nodePool)
+	machinePool := createTestMachinePool(namespace, nodePoolName, clusterName)
+	cluster := createTestCluster(namespace, clusterName)
+	aroControlPlane := createTestAROControlPlane(namespace, clusterName)
+	aroCluster := createTestAROCluster(namespace, clusterName)
+	aroClusterIdentity := createTestAROClusterIdentity(namespace, "test-identity")
+
+	mgmtScheme := runtime.NewScheme()
+	_ = infrav1.AddToScheme(mgmtScheme)
+	_ = infrav2exp.AddToScheme(mgmtScheme)
+	_ = cplane.AddToScheme(mgmtScheme)
+	_ = clusterv1.AddToScheme(mgmtScheme)
+	_ = asoredhatopenshiftv1.AddToScheme(mgmtScheme)
+
+	mgmtClient := fake.NewClientBuilder().
+		WithScheme(mgmtScheme).
+		WithObjects(aroMachinePool, machinePool, cluster, aroControlPlane, aroCluster, aroClusterIdentity, nodePool, hcpCluster).
+		WithStatusSubresource(aroMachinePool).
+		Build()
+
+	mpScope, err := scope.NewAROMachinePoolScope(ctx, scope.AROMachinePoolScopeParams{
+		Client:         mgmtClient,
+		Cluster:        cluster,
+		ControlPlane:   aroControlPlane,
+		MachinePool:    machinePool,
+		AROMachinePool: aroMachinePool,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tracker := &FakeClusterTracker{
+		getClientFunc: func(ctx context.Context, name types.NamespacedName) (client.Client, error) {
+			return managedClusterClient, nil
+		},
+	}
+
+	reconcilerService := &aroMachinePoolService{
+		scope:      mpScope,
+		kubeclient: mgmtClient,
+		tracker:    tracker,
+		cluster:    cluster,
+		newResourceReconciler: func(machinePool *infrav2exp.AROMachinePool, resources []*unstructured.Unstructured) resourceReconciler {
+			return basecontrollers.NewResourceReconciler(mgmtClient, resources, machinePool)
+		},
+	}
+
+	err = reconcilerService.Reconcile(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Without reading baseDomainPrefix, the code would construct
+	// "ethos700-dev-va7-watsonxcomp1" and find zero matches.
+	// With the fix, it reads "f4k6p2z2p0z9b3a" from HcpOpenShiftCluster
+	// and constructs "f4k6p2z2p0z9b3a-watsonxcomp1" which matches.
+	g.Expect(aroMachinePool.Spec.ProviderIDList).To(HaveLen(1))
+	g.Expect(aroMachinePool.Spec.ProviderIDList).To(ContainElement(nodes[0].Spec.ProviderID))
+}
+
 // Helper functions to create test objects
 
 func createTestAROMachinePool(namespace, name, clusterName string, nodePool *asoredhatopenshiftv1.HcpOpenShiftClustersNodePool) *infrav2exp.AROMachinePool {

--- a/exp/controllers/aromachinepool_reconciler.go
+++ b/exp/controllers/aromachinepool_reconciler.go
@@ -249,7 +249,15 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 			azureNodePoolName = azureName
 		}
 
-		hypershiftNodePoolName := s.scope.ClusterName() + "-" + azureNodePoolName
+		// The hypershift.openshift.io/nodePool label is <baseDomainPrefix>-<azureName>.
+		// The baseDomainPrefix may differ from the CAPI cluster name when
+		// explicitly set on HcpOpenShiftCluster.spec.properties.dns.
+		hypershiftPrefix := s.scope.ClusterName()
+		if prefix := s.getBaseDomainPrefix(ctx); prefix != "" {
+			hypershiftPrefix = prefix
+		}
+
+		hypershiftNodePoolName := hypershiftPrefix + "-" + azureNodePoolName
 		nodes := &corev1.NodeList{}
 		err = clusterClient.List(ctx, nodes,
 			client.MatchingLabels(expectedNodeLabels(hypershiftNodePoolName)),
@@ -451,9 +459,31 @@ func (s *aroMachinePoolService) deleteResources(ctx context.Context) error {
 
 // getHcpClusterName retrieves the HCP cluster name from the control plane.
 func (s *aroMachinePoolService) getHcpClusterName() string {
-	// The HCP cluster name should match the CAPI cluster name
-	// This is consistent with how AROControlPlane names its HcpOpenShiftCluster
 	return s.scope.ClusterName()
+}
+
+// getBaseDomainPrefix reads the baseDomainPrefix from the HcpOpenShiftCluster
+// status. This is the prefix used in the hypershift.openshift.io/nodePool node
+// label and may differ from the CAPI cluster name.
+func (s *aroMachinePoolService) getBaseDomainPrefix(ctx context.Context) string {
+	name := client.ObjectKey{Namespace: s.scope.InfraMachinePool.Namespace, Name: s.getHcpClusterName()}
+
+	v1 := &asoredhatopenshiftv1.HcpOpenShiftCluster{}
+	if err := s.kubeclient.Get(ctx, name, v1); err == nil {
+		if v1.Status.Properties != nil && v1.Status.Properties.Dns != nil && v1.Status.Properties.Dns.BaseDomainPrefix != nil {
+			return *v1.Status.Properties.Dns.BaseDomainPrefix
+		}
+		return ""
+	}
+
+	v2 := &asoredhatopenshiftv1api2025.HcpOpenShiftCluster{}
+	if err := s.kubeclient.Get(ctx, name, v2); err == nil {
+		if v2.Status.Properties != nil && v2.Status.Properties.Dns != nil && v2.Status.Properties.Dns.BaseDomainPrefix != nil {
+			return *v2.Status.Properties.Dns.BaseDomainPrefix
+		}
+	}
+
+	return ""
 }
 
 // expectedNodeLabels returns the labels used to match workload cluster nodes


### PR DESCRIPTION
## Summary

- Read `HcpOpenShiftCluster.status.properties.dns.baseDomainPrefix` from the management cluster to construct the correct `hypershift.openshift.io/nodePool` label selector
- When `baseDomainPrefix` is explicitly set (e.g. `f4k6p2z2p0z9b3a`), it differs from the CAPI cluster name (`ethos700-dev-va7`), causing the previous fix (PR #216) to match zero nodes
- Falls back to CAPI cluster name when `baseDomainPrefix` is not yet available
- Adds test covering the `baseDomainPrefix != CAPI name` scenario

## Test plan

- [x] Unit tests pass (`TestProviderIDListSync_BaseDomainPrefixDiffersFromCAPIName`)
- [x] Verified on test cluster with explicit `baseDomainPrefix: f4k6p2z2p0z9b3a` — MachinePool transitions from Scaling to Running
- [x] Verified without the fix — MachinePool stuck in Scaling with empty providerIDList
- [ ] Customer verification on ethos700-dev-va7 cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)