### PR TITLE
Add Renovate GitHub Actions workflow for manual triggering

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,30 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run Renovate in dry-run mode (no PRs created)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "full"
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          configurationFile: renovate.json
+        env:
+          LOG_LEVEL: info
+          RENOVATE_DRY_RUN: ${{ github.event.inputs['dry-run'] || 'false' }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`.github/workflows/renovate.yaml`) to run Renovate on demand via `workflow_dispatch`
- Includes a dry-run option to test without creating PRs
- Requires a `RENOVATE_TOKEN` repository secret (PAT or GitHub App token)

## Test plan
- [ ] Add `RENOVATE_TOKEN` secret to the repository
- [ ] Trigger the workflow manually from Actions tab with dry-run set to `full`
- [ ] Verify Renovate runs and logs appear correctly
- [ ] Trigger again with dry-run set to `false` and verify PRs are created as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new automated workflow for dependency management with flexible execution options—manual triggers for on-demand runs and dry-run mode for testing proposed changes
  * Teams can now control update timing directly and preview modifications before they're applied to the repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->