### PR TITLE
fix: use GITHUB_TOKEN for Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
         env:
           LOG_LEVEL: info


### PR DESCRIPTION
## Summary
- Fixes Renovate workflow failure: `'token' MUST be passed using its input or the 'RENOVATE_TOKEN' environment variable`
- Switches from `secrets.RENOVATE_TOKEN` (not defined) to `secrets.GITHUB_TOKEN`

**Note:** `GITHUB_TOKEN` cannot update GitHub Actions workflows themselves. If full Renovate functionality is needed later, a dedicated PAT or GitHub App token should be configured as `RENOVATE_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)