### PR TITLE
ACM-31038: Enable FIPS by building with CGO_ENABLED=1

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9-1778186187 AS toolchain
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -23,10 +23,10 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-extldflags '-static'" -o ./manager .
+    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} go build -o ./manager .
 
 # Copy the aso-controller into a thin image
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1778461714
 COPY --from=builder /workspace/manager /manager
-USER nonroot:nonroot
+USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary
- Set `CGO_ENABLED=1` in the Dockerfile build step to enable FIPS-compliant Go crypto
- remove --static flag
- upgrade to ubi9