### PR TITLE
Add main branch to Tekton mce-51 push pipeline trigger

### DIFF
--- a/.tekton/cluster-api-provider-azure-mce-51-push.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-51-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "backplane-5.1"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && (target_branch
+      == "backplane-5.1" || target_branch == "main")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-mce-51


### PR DESCRIPTION
## Summary
- Adds `|| target_branch == "main"` to the CEL expression in the mce-51 push Tekton config
- The pull-request config was already updated in a prior change
- Since `backplane-5.1` is always fast-forwarded from `main`, the same pipeline should trigger on pushes targeting `main`

## Test plan
- [ ] Verify Tekton push pipeline triggers on pushes to `main`
- [ ] Verify existing `backplane-5.1` triggers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline automation to trigger on push events to both the backplane-5.1 and main branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->