### PR TITLE
fix: add main and backplane-5.x to weekly security scan

### DIFF
--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [backplane-2.11, backplane-2.17]
+        branch: [main, backplane-2.11, backplane-2.17, backplane-5.0, backplane-5.1]
     name: Trivy (${{ matrix.branch }})
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- The weekly security scan matrix only covered `backplane-2.11` and `backplane-2.17`, completely missing `main` and the newer `backplane-5.x` branches
- Add `main`, `backplane-5.0`, and `backplane-5.1` to the Trivy scan matrix so all active branches are scanned for vulnerabilities

Jira: [ARO-26962](https://redhat.atlassian.net/browse/ARO-26962)

[ARO-26962]: https://redhat.atlassian.net/browse/ARO-26962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced weekly security scanning to include the main branch in addition to existing branch coverage, ensuring consistent vulnerability assessments across all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->