### PR TITLE
Add CI check to block PRs targeting backplane branches

### DIFF
--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -5,10 +5,16 @@ on:
     branches:
       - "backplane-*"
 
+permissions: {}
+
 jobs:
   block:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
       - name: Block PR
         run: |
           echo "::error::Direct pull requests to backplane branches are not accepted."

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -2,6 +2,7 @@ name: Protect backplane branches
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, edited]
     branches:
       - "backplane-*"
 

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -1,0 +1,16 @@
+name: Protect backplane branches
+
+on:
+  pull_request:
+    branches:
+      - "backplane-*"
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PR
+        run: |
+          echo "::error::Direct pull requests to backplane branches are not accepted."
+          echo "::error::Changes are synced from main via fast-forward. Please target your PR to the main branch instead."
+          exit 1

--- a/.github/workflows/protect-backplane-branches.yaml
+++ b/.github/workflows/protect-backplane-branches.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
     branches:
-      - "backplane-*"
+      - "backplane-5*"
 
 permissions: {}
 
@@ -18,6 +18,6 @@ jobs:
           egress-policy: audit
       - name: Block PR
         run: |
-          echo "::error::Direct pull requests to backplane branches are not accepted."
+          echo "::error::Direct pull requests to backplane-5.x branches are not accepted."
           echo "::error::Changes are synced from main via fast-forward. Please target your PR to the main branch instead."
           exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a GitHub Actions workflow that fails any PR targeting `backplane-*` branches. Backplane branches are synced from `main` via fast-forward (`ffwd-branch.yaml`), so direct PRs are unnecessary and can cause divergence. The workflow prints a clear error message directing contributors to target `main` instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Ref: [ARO-27157](https://redhat.atlassian.net/browse/ARO-27157)

**Special notes for your reviewer**:

The workflow includes:
- `permissions: {}` for least-privilege (consistent with all repo workflows)
- `step-security/harden-runner` for OpenSSF Scorecard compliance
- Explicit `types: [opened, reopened, synchronize, edited]` to catch base-branch retargeting

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```

[ARO-27157]: https://redhat.atlassian.net/browse/ARO-27157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated branch protection to prevent pull requests from being merged into specific release branches, helping maintain code integrity and control over critical deployment paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->