### PR TITLE
Add FIPS build flags and upgrade builder to UBI9

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9-1778186187 AS toolchain
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -23,7 +23,7 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-extldflags '-static'" -o ./manager .
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GOARCH=${ARCH} go build -o ./manager .
 
 # Copy the aso-controller into a thin image
 FROM registry.access.redhat.com/ubi9/ubi:9.7-1778461714


### PR DESCRIPTION
## Summary
- Upgrade builder from `ubi8/go-toolset:1.25` to `ubi9/go-toolset:1.25` for FIPS-compatible OpenSSL 3.x
- Change `CGO_ENABLED=0` to `CGO_ENABLED=1` and add `GOEXPERIMENT=strictfipsruntime` for FIPS compliance
- Remove `-extldflags '-static'` (incompatible with CGO-based FIPS)

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)