### PR TITLE
ARO-26765: Fix AROMachinePool node matching using HyperShift labels - Sync backplane-2.17 to main

### DIFF
--- a/exp/controllers/aromachinepool_providerid_test.go
+++ b/exp/controllers/aromachinepool_providerid_test.go
@@ -307,6 +307,137 @@ func TestProviderIDListSync_AzureNameDiffersFromK8sName(t *testing.T) {
 	g.Expect(aroMachinePool.Spec.ProviderIDList).To(ContainElement(nodes[1].Spec.ProviderID))
 }
 
+// TestProviderIDListSync_BaseDomainPrefixDiffersFromCAPIName tests the case where
+// HcpOpenShiftCluster.status.properties.dns.baseDomainPrefix differs from the
+// CAPI cluster name. The node label uses the baseDomainPrefix, so we must read
+// it from the HcpOpenShiftCluster on the management cluster.
+func TestProviderIDListSync_BaseDomainPrefixDiffersFromCAPIName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	const (
+		clusterName       = "ethos700-dev-va7"
+		namespace         = "ethos700-dev-va7"
+		nodePoolName      = "ethos700-dev-va7-watsonxcomp-1"
+		azureName         = "watsonxcomp1"
+		baseDomainPrefix  = "f4k6p2z2p0z9b3a" // differs from CAPI cluster name
+		subscriptionID    = "00000000-0000-0000-0000-000000000000"
+		resourceGroupName = "ethos_700_dev_va7"
+	)
+
+	// Nodes use baseDomainPrefix in labels, NOT the CAPI cluster name
+	nodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   baseDomainPrefix + "-" + azureName + "-wpcr6-95pzn",
+				Labels: expectedNodeLabels(baseDomainPrefix + "-" + azureName),
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/" + baseDomainPrefix + "-" + azureName + "-wpcr6-95pzn",
+			},
+		},
+	}
+
+	managedClusterScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(managedClusterScheme)
+	managedClusterClient := fake.NewClientBuilder().
+		WithScheme(managedClusterScheme).
+		WithObjects(&nodes[0]).
+		Build()
+
+	nodePool := &asoredhatopenshiftv1.HcpOpenShiftClustersNodePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HcpOpenShiftClustersNodePool",
+			APIVersion: asoredhatopenshiftv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodePoolName,
+			Namespace: namespace,
+		},
+		Spec: asoredhatopenshiftv1.HcpOpenShiftClustersNodePool_Spec{
+			AzureName: azureName,
+			Owner: &genruntime.KnownResourceReference{
+				Name: clusterName,
+			},
+		},
+		Status: asoredhatopenshiftv1.HcpOpenShiftClustersNodePool_STATUS{
+			Properties: &asoredhatopenshiftv1.NodePoolProperties_STATUS{
+				Replicas: ptr.To(1),
+			},
+		},
+	}
+
+	// HcpOpenShiftCluster on the management cluster with baseDomainPrefix in status
+	hcpCluster := &asoredhatopenshiftv1.HcpOpenShiftCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Status: asoredhatopenshiftv1.HcpOpenShiftCluster_STATUS{
+			Properties: &asoredhatopenshiftv1.HcpOpenShiftClusterProperties_STATUS{
+				Dns: &asoredhatopenshiftv1.DnsProfile_STATUS{
+					BaseDomainPrefix: ptr.To(baseDomainPrefix),
+				},
+			},
+		},
+	}
+
+	aroMachinePool := createTestAROMachinePool(namespace, nodePoolName, clusterName, nodePool)
+	machinePool := createTestMachinePool(namespace, nodePoolName, clusterName)
+	cluster := createTestCluster(namespace, clusterName)
+	aroControlPlane := createTestAROControlPlane(namespace, clusterName)
+	aroCluster := createTestAROCluster(namespace, clusterName)
+	aroClusterIdentity := createTestAROClusterIdentity(namespace, "test-identity")
+
+	mgmtScheme := runtime.NewScheme()
+	_ = infrav1.AddToScheme(mgmtScheme)
+	_ = infrav2exp.AddToScheme(mgmtScheme)
+	_ = cplane.AddToScheme(mgmtScheme)
+	_ = clusterv1.AddToScheme(mgmtScheme)
+	_ = asoredhatopenshiftv1.AddToScheme(mgmtScheme)
+
+	mgmtClient := fake.NewClientBuilder().
+		WithScheme(mgmtScheme).
+		WithObjects(aroMachinePool, machinePool, cluster, aroControlPlane, aroCluster, aroClusterIdentity, nodePool, hcpCluster).
+		WithStatusSubresource(aroMachinePool).
+		Build()
+
+	mpScope, err := scope.NewAROMachinePoolScope(ctx, scope.AROMachinePoolScopeParams{
+		Client:         mgmtClient,
+		Cluster:        cluster,
+		ControlPlane:   aroControlPlane,
+		MachinePool:    machinePool,
+		AROMachinePool: aroMachinePool,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tracker := &FakeClusterTracker{
+		getClientFunc: func(ctx context.Context, name types.NamespacedName) (client.Client, error) {
+			return managedClusterClient, nil
+		},
+	}
+
+	reconcilerService := &aroMachinePoolService{
+		scope:      mpScope,
+		kubeclient: mgmtClient,
+		tracker:    tracker,
+		cluster:    cluster,
+		newResourceReconciler: func(machinePool *infrav2exp.AROMachinePool, resources []*unstructured.Unstructured) resourceReconciler {
+			return basecontrollers.NewResourceReconciler(mgmtClient, resources, machinePool)
+		},
+	}
+
+	err = reconcilerService.Reconcile(ctx)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Without reading baseDomainPrefix, the code would construct
+	// "ethos700-dev-va7-watsonxcomp1" and find zero matches.
+	// With the fix, it reads "f4k6p2z2p0z9b3a" from HcpOpenShiftCluster
+	// and constructs "f4k6p2z2p0z9b3a-watsonxcomp1" which matches.
+	g.Expect(aroMachinePool.Spec.ProviderIDList).To(HaveLen(1))
+	g.Expect(aroMachinePool.Spec.ProviderIDList).To(ContainElement(nodes[0].Spec.ProviderID))
+}
+
 // Helper functions to create test objects
 
 func createTestAROMachinePool(namespace, name, clusterName string, nodePool *asoredhatopenshiftv1.HcpOpenShiftClustersNodePool) *infrav2exp.AROMachinePool {

--- a/exp/controllers/aromachinepool_providerid_test.go
+++ b/exp/controllers/aromachinepool_providerid_test.go
@@ -57,12 +57,13 @@ func TestProviderIDListSync_AzureNameMatchesK8sName(t *testing.T) {
 		resourceGroupName = "test-rg"
 	)
 
-	// Create nodes in the managed cluster with the expected naming pattern
-	// Pattern: <clusterName>-<azureName>-<suffix>
+	// Create nodes in the managed cluster with the expected HyperShift labels
+	// Label: hypershift.openshift.io/nodePool=<clusterName>-<azureName>
 	nodes := []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-cluster-test-cluster-mp1-abc123",
+				Name:   "test-cluster-test-cluster-mp1-abc123",
+				Labels: expectedNodeLabels(clusterName + "-" + azureName),
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/test-cluster-test-cluster-mp1-abc123",
@@ -70,7 +71,8 @@ func TestProviderIDListSync_AzureNameMatchesK8sName(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-cluster-test-cluster-mp1-def456",
+				Name:   "test-cluster-test-cluster-mp1-def456",
+				Labels: expectedNodeLabels(clusterName + "-" + azureName),
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/test-cluster-test-cluster-mp1-def456",
@@ -190,7 +192,8 @@ func TestProviderIDListSync_AzureNameDiffersFromK8sName(t *testing.T) {
 	nodes := []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "aro04-sbx-va7-workeraro1-9cg4d-qjx25",
+				Name:   "aro04-sbx-va7-workeraro1-9cg4d-qjx25",
+				Labels: expectedNodeLabels(clusterName + "-" + azureName),
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/aro04-sbx-va7-workeraro1-9cg4d-qjx25",
@@ -198,7 +201,8 @@ func TestProviderIDListSync_AzureNameDiffersFromK8sName(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "aro04-sbx-va7-workeraro1-9cg4d-slvd6",
+				Name:   "aro04-sbx-va7-workeraro1-9cg4d-slvd6",
+				Labels: expectedNodeLabels(clusterName + "-" + azureName),
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure:///subscriptions/" + subscriptionID + "/resourceGroups/" + resourceGroupName + "-managed/providers/Microsoft.Compute/virtualMachines/aro04-sbx-va7-workeraro1-9cg4d-slvd6",

--- a/exp/controllers/aromachinepool_reconciler.go
+++ b/exp/controllers/aromachinepool_reconciler.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
+	"slices"
 	"time"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20240610preview"
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -236,66 +237,50 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 		s.scope.InfraMachinePool.Status.Replicas = *s.scope.MachinePool.Spec.Replicas
 	}
 
-	// Populate providerIDList from workload cluster nodes
-	// This is required by CAPI to match MachinePool replicas to actual nodes
-	// Get client for the workload cluster (not management cluster)
+	// Populate providerIDList from workload cluster nodes using label-based matching.
+	// This mirrors the approach used by AzureASOManagedMachinePool.
 	clusterClient, err := s.tracker.GetClient(ctx, util.ObjectKey(s.cluster))
 	if err != nil {
 		log.V(4).Info("failed to get workload cluster client", "error", err)
 		// Don't fail reconciliation if we can't get cluster client yet - control plane may not be ready
 	} else {
-		// List all nodes from the workload cluster
-		// Note: We list all nodes and filter by node pool name pattern rather than using labels
-		// This is because ARO HCP node labels may vary
+		azureNodePoolName := nodePoolName
+		if azureName != "" {
+			azureNodePoolName = azureName
+		}
+
+		hypershiftNodePoolName := s.scope.ClusterName() + "-" + azureNodePoolName
 		nodes := &corev1.NodeList{}
-		err = clusterClient.List(ctx, nodes)
+		err = clusterClient.List(ctx, nodes,
+			client.MatchingLabels(expectedNodeLabels(hypershiftNodePoolName)),
+		)
 		if err != nil {
 			log.V(4).Info("failed to list nodes in workload cluster", "error", err)
-			// Don't fail reconciliation if we can't list nodes yet
 		} else {
-			// Determine the Azure node pool name to use for pattern matching
-			// ARO HCP uses spec.azureName (if set) when creating nodes, not the k8s resource name
-			azureNodePoolName := nodePoolName // Default to k8s resource name for backward compatibility
-			if azureName != "" {
-				azureNodePoolName = azureName
-			}
-
-			// Filter nodes by providerID pattern matching this node pool
-			// ARO HCP node names contain the node pool name: <cluster-name>-<azureName>-<random-suffix>
-			nodePoolNamePattern := s.scope.ClusterName() + "-" + azureNodePoolName + "-"
-			var providerIDs []string
+			providerIDs := make([]string, 0, len(nodes.Items))
 			for _, node := range nodes.Items {
 				if node.Spec.ProviderID == "" {
-					// The node will receive a provider ID soon
 					log.V(4).Info("node does not have providerID yet", "nodeName", node.Name)
 					continue
 				}
-				// Check if the node name matches the expected pattern for this node pool
-				if strings.Contains(node.Name, nodePoolNamePattern) {
-					providerIDs = append(providerIDs, node.Spec.ProviderID)
-				}
+				providerIDs = append(providerIDs, node.Spec.ProviderID)
 			}
+			slices.Sort(providerIDs)
 
-			// Set the provider IDs on the AROMachinePool
 			s.scope.SetAgentPoolProviderIDList(providerIDs)
 
-			// Update replicas count based on actual nodes if we successfully listed them
-			// This ensures the replica count matches the actual number of nodes
 			currentReplicas := int32(len(providerIDs))
 			if currentReplicas > 0 {
 				s.scope.InfraMachinePool.Status.Replicas = currentReplicas
 
-				// If autoscaling is enabled, update MachinePool.Spec.Replicas to match actual count
-				// This prevents CAPI from thinking we're in a ScalingDown state when autoscaler scales up
+				// Sync spec.replicas to prevent CAPI from reporting incorrect ScalingDown state when autoscaler scales up
 				if _, autoscaling := s.scope.MachinePool.Annotations[clusterv1.ReplicasManagedByAnnotation]; autoscaling {
 					s.scope.MachinePool.Spec.Replicas = &currentReplicas
 				}
 			}
 
 			log.V(4).Info("populated providerIDList from workload cluster nodes",
-				"k8sNodePoolName", nodePoolName,
 				"azureNodePoolName", azureNodePoolName,
-				"nodePoolNamePattern", nodePoolNamePattern,
 				"providerIDCount", len(providerIDs))
 		}
 	}
@@ -469,4 +454,16 @@ func (s *aroMachinePoolService) getHcpClusterName() string {
 	// The HCP cluster name should match the CAPI cluster name
 	// This is consistent with how AROControlPlane names its HcpOpenShiftCluster
 	return s.scope.ClusterName()
+}
+
+// expectedNodeLabels returns the labels used to match workload cluster nodes
+// to an ARO-HCP node pool. The nodePoolName is the HyperShift NodePool name,
+// constructed as <cluster-name>-<azureNodePoolName>.
+func expectedNodeLabels(nodePoolName string) map[string]string {
+	if len(nodePoolName) > validation.LabelValueMaxLength {
+		nodePoolName = nodePoolName[:validation.LabelValueMaxLength]
+	}
+	return map[string]string{
+		"hypershift.openshift.io/nodePool": nodePoolName,
+	}
 }

--- a/exp/controllers/aromachinepool_reconciler.go
+++ b/exp/controllers/aromachinepool_reconciler.go
@@ -249,7 +249,15 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 			azureNodePoolName = azureName
 		}
 
-		hypershiftNodePoolName := s.scope.ClusterName() + "-" + azureNodePoolName
+		// The hypershift.openshift.io/nodePool label is <baseDomainPrefix>-<azureName>.
+		// The baseDomainPrefix may differ from the CAPI cluster name when
+		// explicitly set on HcpOpenShiftCluster.spec.properties.dns.
+		hypershiftPrefix := s.scope.ClusterName()
+		if prefix := s.getBaseDomainPrefix(ctx); prefix != "" {
+			hypershiftPrefix = prefix
+		}
+
+		hypershiftNodePoolName := hypershiftPrefix + "-" + azureNodePoolName
 		nodes := &corev1.NodeList{}
 		err = clusterClient.List(ctx, nodes,
 			client.MatchingLabels(expectedNodeLabels(hypershiftNodePoolName)),
@@ -451,9 +459,31 @@ func (s *aroMachinePoolService) deleteResources(ctx context.Context) error {
 
 // getHcpClusterName retrieves the HCP cluster name from the control plane.
 func (s *aroMachinePoolService) getHcpClusterName() string {
-	// The HCP cluster name should match the CAPI cluster name
-	// This is consistent with how AROControlPlane names its HcpOpenShiftCluster
 	return s.scope.ClusterName()
+}
+
+// getBaseDomainPrefix reads the baseDomainPrefix from the HcpOpenShiftCluster
+// status. This is the prefix used in the hypershift.openshift.io/nodePool node
+// label and may differ from the CAPI cluster name.
+func (s *aroMachinePoolService) getBaseDomainPrefix(ctx context.Context) string {
+	name := client.ObjectKey{Namespace: s.scope.InfraMachinePool.Namespace, Name: s.getHcpClusterName()}
+
+	v1 := &asoredhatopenshiftv1.HcpOpenShiftCluster{}
+	if err := s.kubeclient.Get(ctx, name, v1); err == nil {
+		if v1.Status.Properties != nil && v1.Status.Properties.Dns != nil && v1.Status.Properties.Dns.BaseDomainPrefix != nil {
+			return *v1.Status.Properties.Dns.BaseDomainPrefix
+		}
+		return ""
+	}
+
+	v2 := &asoredhatopenshiftv1api2025.HcpOpenShiftCluster{}
+	if err := s.kubeclient.Get(ctx, name, v2); err == nil {
+		if v2.Status.Properties != nil && v2.Status.Properties.Dns != nil && v2.Status.Properties.Dns.BaseDomainPrefix != nil {
+			return *v2.Status.Properties.Dns.BaseDomainPrefix
+		}
+	}
+
+	return ""
 }
 
 // expectedNodeLabels returns the labels used to match workload cluster nodes


### PR DESCRIPTION
**What type of PR is this?**
* [ARO-26765](https://redhat.atlassian.net/browse/ARO-26765) : Fix AROMachinePool node matching using HyperShift labels
* This is sync to main of:
   *  #216 and
   *  #241
   

[ARO-26765]: https://redhat.atlassian.net/browse/ARO-26765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for provider ID synchronization with additional scenarios for base domain prefix configurations.

* **Refactor**
  * Improved ARO machine pool node selection to use label-based matching for better compatibility with HyperShift clusters, including automatic replica count synchronization and support for base domain prefix variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->