### PR TITLE
fix: use SYNC_PAT for upstream sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SYNC_PAT }}
           ref: ${{ matrix.target }}
 
       - name: Configure git
@@ -78,7 +78,7 @@ jobs:
         if: steps.find-commits.outputs.count != '0'
         id: existing-pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
           TARGET: ${{ matrix.target }}
         run: |
           PR_NUMBER="$(
@@ -176,7 +176,7 @@ jobs:
       - name: Push and create draft PR
         if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied != '0'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
           SYNC_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
           APPLIED: ${{ steps.cherry-pick.outputs.applied }}
           TOTAL: ${{ steps.cherry-pick.outputs.total }}


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with `SYNC_PAT` in the upstream sync workflow
- The default `GITHUB_TOKEN` cannot create pull requests due to org-level restrictions (`Resource not accessible by integration`)
- `SYNC_PAT` is a fine-grained PAT scoped to this repository with contents and pull-requests write permissions

## Test plan

- [x] Verify the three token references are updated (checkout, existing PR check, PR creation)
- [ ] After merge, trigger the Upstream Sync workflow manually and confirm draft PRs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub authentication configuration for upstream synchronization workflows to use a repository-specific credential mechanism, enhancing security for automated sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->