### PR TITLE
fix: use full Konflux check name with 'Red Hat Konflux /' prefix

### DIFF
--- a/.github/workflows/pr-capi-tests.yaml
+++ b/.github/workflows/pr-capi-tests.yaml
@@ -44,15 +44,15 @@ jobs:
           set -euo pipefail
           case "$BASE_REF" in
             main)
-              echo "konflux_check=cluster-api-provider-azure-mce-50-on-pull-request" >> "$GITHUB_OUTPUT"
+              echo "konflux_check=Red Hat Konflux / cluster-api-provider-azure-mce-50-on-pull-request" >> "$GITHUB_OUTPUT"
               echo "aro_branch=backplane-5.0" >> "$GITHUB_OUTPUT"
               ;;
             backplane-2.17)
-              echo "konflux_check=cluster-api-provider-azure-mce-217-on-pull-request" >> "$GITHUB_OUTPUT"
+              echo "konflux_check=Red Hat Konflux / cluster-api-provider-azure-mce-217-on-pull-request" >> "$GITHUB_OUTPUT"
               echo "aro_branch=backplane-2.17" >> "$GITHUB_OUTPUT"
               ;;
             backplane-2.11)
-              echo "konflux_check=cluster-api-provider-azure-mce-211-on-pull-request" >> "$GITHUB_OUTPUT"
+              echo "konflux_check=Red Hat Konflux / cluster-api-provider-azure-mce-211-on-pull-request" >> "$GITHUB_OUTPUT"
               echo "aro_branch=backplane-2.11" >> "$GITHUB_OUTPUT"
               ;;
             *)


### PR DESCRIPTION
## Summary

- Fix the `pr-capi-tests` workflow to use the full Konflux check run name including the `Red Hat Konflux / ` prefix
- The Konflux GitHub App reports check runs as e.g. `Red Hat Konflux / cluster-api-provider-azure-mce-50-on-pull-request`, but the workflow was searching for the bare name without the prefix, so the check was never found (visible as endless "Check not found yet" in [PR #275 logs](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/26519710196/job/78106891253?pr=275))

## Test plan

- [ ] Verify `capi-tests (main)` check on this PR finds the Konflux check run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to standardize output formatting for branch mapping steps.

---

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->