### PR TITLE
Sync upstream/release-1.22 into backplane-2.17

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -17,6 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+set -o xtrace
+
 version::get_version_vars() {
     # shellcheck disable=SC1083
     GIT_COMMIT="$(git rev-parse HEAD^{commit})"

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -104,7 +104,7 @@ func (acp *AzureClusterProxy) CollectWorkloadClusterLogs(ctx context.Context, na
 }
 
 func (acp *AzureClusterProxy) collectPodLogs(ctx context.Context, namespace string, name string, aboveMachinesPath string) {
-	workload := acp.ClusterProxy.GetWorkloadCluster(ctx, namespace, name)
+	workload := acp.GetWorkloadCluster(ctx, namespace, name)
 	pods := &corev1.PodList{}
 
 	Expect(workload.GetClient().List(ctx, pods)).To(Succeed())
@@ -187,7 +187,7 @@ func collectContainerLogs(ctx context.Context, pod corev1.Pod, container corev1.
 }
 
 func (acp *AzureClusterProxy) collectNodes(ctx context.Context, namespace string, name string, aboveMachinesPath string) {
-	workload := acp.ClusterProxy.GetWorkloadCluster(ctx, namespace, name)
+	workload := acp.GetWorkloadCluster(ctx, namespace, name)
 	nodes := &corev1.NodeList{}
 
 	// Failing to collect node logs should not cause the test to fail. The workload cluster
@@ -229,7 +229,7 @@ func (acp *AzureClusterProxy) collectActivityLogs(ctx context.Context, namespace
 	activityLogsClient, err := armmonitor.NewActivityLogsClient(getSubscriptionID(Default), cred, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	clusterClient := acp.ClusterProxy.GetClient()
+	clusterClient := acp.GetClient()
 	cluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
 		Getter:    clusterClient,
 		Name:      name,

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -190,7 +190,14 @@ func (acp *AzureClusterProxy) collectNodes(ctx context.Context, namespace string
 	workload := acp.ClusterProxy.GetWorkloadCluster(ctx, namespace, name)
 	nodes := &corev1.NodeList{}
 
-	Expect(workload.GetClient().List(ctx, nodes)).To(Succeed())
+	// Failing to collect node logs should not cause the test to fail. The workload cluster
+	// API server may be unreachable during teardown (for example due to a transient Azure
+	// load balancer / DNS issue), and we should not turn an otherwise-successful spec into
+	// a failure during [AfterEach] log collection.
+	if err := workload.GetClient().List(ctx, nodes); err != nil {
+		Logf("Failed to list nodes for workload cluster %s/%s: %v", namespace, name, err)
+		return
+	}
 
 	var err error
 	var nodeDescribe string


### PR DESCRIPTION
## Summary
- Cherry-picked all missing commits from `upstream/release-1.23` into `backplane-2.17`
- 61 commits synced covering CAPI bumps, dependency updates, e2e fixes, and Go toolchain upgrades

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify existing tests pass
- [ ] Confirm no regressions in ARO/HCP controller functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)