### PR TITLE
Regenerate RBAC role: add missing AROControlPlane and KeyVault permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -164,6 +164,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - arocontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - arocontrolplanes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - arocontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - aroclusters
@@ -230,6 +256,18 @@ rules:
   resources:
   - azuremachinetemplates/status
   verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - keyvault.azure.com
+  resources:
+  - vaults
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
## Summary
- Running `make generate` on `backplane-2.11` revealed missing RBAC rules that were never regenerated when ARO controllers were added
- Adds `arocontrolplanes` CRUD + finalizers + status permissions (controlplane.cluster.x-k8s.io) needed by the AROControlPlane controller
- Adds `keyvault.azure.com/vaults` CRUD permissions for ASO KeyVault resource management

## Test plan
- [ ] Verify `make generate` produces no further diff
- [ ] Verify `go build ./...` passes
- [ ] Confirm AROControlPlane controller can manage resources without RBAC errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)