### PR TITLE
fix: disable codecov upload on backplane-2.11 (ARO-27418)

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -26,9 +26,9 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
-    - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        files: ./coverage.out
-        fail_ci_if_error: true
+#     - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+#       env:
+#         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#       with:
+#         files: ./coverage.out
+#         fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Disables the codecov upload step on `backplane-2.11` to fix the failing `coverage` check on all PRs targeting this branch.

JIRA: https://redhat.atlassian.net/browse/ARO-27418

## Problem

The `coverage` GitHub Actions check fails on PRs targeting `backplane-2.11` because the `codecov/codecov-action` step requires a `CODECOV_TOKEN` secret that is not configured in the stolostron repo. The step is configured with `fail_ci_if_error: true`, which causes the entire job to fail.

Error:
```
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

## Root cause analysis

**Why only `backplane-2.11` is affected:**

| Branch | codecov step | Status |
|--------|-------------|--------|
| `main` | commented out | OK |
| `backplane-2.17` | commented out | OK |
| `backplane-2.11` | **active** | FAILING |

- `main` had the codecov step disabled as part of the stolostron downstream build infrastructure setup (`e18992c2`, 2026-05-06)
- `backplane-2.17` received the fix via an upstream sync from `release-1.22` which already had it disabled
- `backplane-2.11` was missed — it syncs from an older upstream release branch that still has the codecov step active, and the downstream build infra commit that fixed `main` was never cherry-picked to this branch

## Solution

Comment out the `codecov/codecov-action` step in `.github/workflows/cover.yaml` to align with `main` and `backplane-2.17`.

## Changes

- `.github/workflows/cover.yaml` — comment out the codecov upload step (6 lines)

## Testing

- No functional tests affected — the codecov step only uploads coverage reports, it doesn't run tests
- The `make test-cover` step that actually runs tests remains unchanged

Ref: ARO-27418

Generated with [Claude Code](https://claude.com/claude-code)