### PR TITLE
fix: scope upstream-sync workflow permissions to job level

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -6,13 +6,12 @@ on:
     - cron: '17 8 * * 1'  # Every Monday at 08:17 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 30
     concurrency:
       group: upstream-sync-${{ matrix.target }}

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -10,8 +10,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # for pushing sync branches
+      pull-requests: write  # for creating draft sync PRs
     timeout-minutes: 30
     concurrency:
       group: upstream-sync-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Moves `permissions` block in `upstream-sync.yml` from workflow-level to job-level
- Resolves [code-scanning alert #39](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/39) (OpenSSF Scorecard Token-Permissions)
- No functional change — same permissions, just scoped to the `sync` job

## Test plan
- [ ] Verify Scorecard re-scan no longer flags the alert
- [ ] Run upstream-sync workflow via `workflow_dispatch` to confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI workflow permission scope: removed broad workflow-level permissions and applied them at the specific sync job level.
  * The sync job now explicitly grants write permissions for repository contents and pull requests to better constrain CI privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->