### PR TITLE
fix: add actions language to CodeQL scanning matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "python"]
-        # CodeQL supports [ $supported-codeql-languages ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ["actions", "go", "python"]
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
+        if: matrix.language != 'actions'
         uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
 
       # ℹ️ Command-line programs to run using the OS shell.


### PR DESCRIPTION
## Summary
- Adds `actions` to the CodeQL language matrix in `.github/workflows/codeql.yml`
- GitHub detects `actions`, `go`, and `python` as scannable languages, but only `go` and `python` were configured — causing a "Code scanning configuration error" on the Security tab
- The `actions` language scans GitHub Actions workflow YAML files for security issues like script injection and overly permissive tokens

## Test plan
- [ ] Verify the CodeQL workflow runs successfully with all three languages (`actions`, `go`, `python`)
- [ ] Confirm the "Code scanning configuration error" disappears from the Security tab after the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded development pipeline to run an additional analyzer/language during automated analysis.
  * Adjusted the automated build gating so the autobuild step is skipped for that added analyzer, avoiding unnecessary build runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->