### PR TITLE
ci: move write permissions to job-level in security scan workflow

### DIFF
--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -6,13 +6,14 @@ on:
     - cron: "0 12 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
-  issues: write
+permissions: {}
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      security-events: write
+      issues: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -11,8 +11,11 @@ permissions: {}
 jobs:
   scan:
     permissions:
+      # Required by actions/checkout to read the scanned branch.
       contents: read
+      # Required by github/codeql-action/upload-sarif to publish SARIF results.
       security-events: write
+      # Required by gh issue create/comment when vulnerabilities are detected.
       issues: write
     strategy:
       fail-fast: false


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Moves `security-events: write` and `issues: write` permissions from workflow-level to job-level in `weekly-security-scan.yaml`, and sets top-level permissions to `permissions: {}`. This aligns with the [upstream workflow](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/workflows/weekly-security-scan.yaml) which already uses `permissions: {}` at the workflow level.

No behavioral change — the `scan` job already needs these permissions and now declares them explicitly at the job level.

**Which issue(s) this PR fixes**:
Fixes https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/36
