### PR TITLE
ci: restrict top-level token permissions in stolostron workflows

### DIFF
--- a/.github/workflows/ffwd-branch.yaml
+++ b/.github/workflows/ffwd-branch.yaml
@@ -8,11 +8,13 @@ on:
 
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   fast-forward:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       TARGET_BRANCHES: backplane-5.0 backplane-5.1
 

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -6,6 +6,9 @@ on:
     - cron: '17 8 * * 1'  # Every Monday at 08:17 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds restrictive top-level `permissions: contents: read` to `upstream-sync.yml` (previously had none)
- Moves `contents: write` from top-level to job-level in `ffwd-branch.yaml`
- No behavioral change — both jobs already have or inherit the write permissions they need

## Code scanning alerts fixed
- [#46](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/46) — no topLevel permission defined (`upstream-sync.yml`)
- [#32](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/32) — topLevel `contents` permission set to `write` (`ffwd-branch.yaml`)