### PR TITLE
ci: build Go with e2e tag for full CodeQL coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,21 +54,13 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        if: matrix.language != 'actions'
+        if: matrix.language != 'actions' && matrix.language != 'go'
         uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: go build -tags e2e ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
CodeQL autobuild runs `go build ./...` without custom build tags, causing 225 Go files with `//go:build e2e` constraints (mostly in `test/e2e/`) to be detected but not analyzed. This results in the ["Go files were found but not processed"](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BOPFWWY/245b02be50f802264f3a091ed5d51073a66f46f1202ea485946e80749158fe2f) warning on the code scanning status page (382 out of 607 Go files scanned).

This PR replaces autobuild for Go with a custom `go build -tags e2e ./...` step so all Go files are included in CodeQL analysis.

**Which issue(s) this PR fixes**:
N/A — addresses CodeQL scanning coverage gap

**Special notes for your reviewer**:
Upstream PR: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6345

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```

## Test plan
- [ ] Verify CodeQL workflow completes successfully for all languages
- [ ] Confirm the "Go files were found but not processed" warning disappears from the Security tab
- [ ] Check that CodeQL now reports scanning all 607 Go files

🤖 Generated with [Claude Code](https://claude.com/claude-code)