### PR TITLE
fix: handle empty cherry-picks in upstream sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -256,7 +256,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Update sync state
-        if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied != '0' && steps.cherry-pick.outputs.last_processed != ''
+        if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && (steps.cherry-pick.outputs.applied != '0' || steps.cherry-pick.outputs.skipped != '0') && steps.cherry-pick.outputs.last_processed != ''
         env:
           LAST_PROCESSED: ${{ steps.cherry-pick.outputs.last_processed }}
         run: |
@@ -410,6 +410,8 @@ jobs:
               echo "| Status | ⏸️ Skipped — open PR #${EXISTING_PR} exists |"
             elif [ "$COMMIT_COUNT" = "0" ]; then
               echo "| Status | ✅ Fully synced |"
+            elif [ "${APPLIED:-0}" -eq 0 ] && [ "${SKIPPED:-0}" -gt 0 ] && [ -z "${CONFLICT_SHA}" ]; then
+              echo "| Status | ✅ All commits already applied |"
             elif [ "${APPLIED:-0}" -eq "${TOTAL:-0}" ] && [ "${TOTAL:-0}" -gt 0 ]; then
               echo "| Status | ✅ All commits applied |"
             else

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -151,12 +151,14 @@ jobs:
           TOTAL=${#SHAS[@]}
           APPLIED=0
           EXCLUDED=0
+          SKIPPED=0
           CONFLICT_SHA=""
           CONFLICT_TITLE=""
           CONFLICT_FULL_SHA=""
           APPLIED_LINES=""
           EXCLUDED_LINES=""
           REMAINING_LINES=""
+          SKIPPED_LINES=""
           HIT_CONFLICT=false
           LAST_PROCESSED=""
 
@@ -197,6 +199,13 @@ jobs:
               LAST_PROCESSED="$SHA"
               APPLIED_LINES=$(printf '%s\n- `%s` %s' "$APPLIED_LINES" "$SHORT" "$TITLE")
               echo "✅ Applied: ${SHORT} ${TITLE}"
+            elif [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+              git cherry-pick --skip
+              SKIPPED=$((SKIPPED + 1))
+              TOTAL=$((TOTAL - 1))
+              LAST_PROCESSED="$SHA"
+              SKIPPED_LINES=$(printf '%s\n- `%s` %s' "$SKIPPED_LINES" "$SHORT" "$TITLE")
+              echo "⏭️ Already applied (empty cherry-pick): ${SHORT} ${TITLE}"
             else
               git cherry-pick --abort 2>/dev/null || true
               HIT_CONFLICT=true
@@ -210,6 +219,7 @@ jobs:
           echo "applied=${APPLIED}" >> "$GITHUB_OUTPUT"
           echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
           echo "excluded=${EXCLUDED}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${SKIPPED}" >> "$GITHUB_OUTPUT"
           echo "last_processed=${LAST_PROCESSED}" >> "$GITHUB_OUTPUT"
           echo "conflict_sha=${CONFLICT_SHA}" >> "$GITHUB_OUTPUT"
           echo "conflict_full_sha=${CONFLICT_FULL_SHA}" >> "$GITHUB_OUTPUT"
@@ -230,6 +240,12 @@ jobs:
           {
             echo "excluded_lines<<${DELIM}"
             echo "$EXCLUDED_LINES"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+          DELIM=$(openssl rand -hex 16)
+          {
+            echo "skipped_lines<<${DELIM}"
+            echo "$SKIPPED_LINES"
             echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
           DELIM=$(openssl rand -hex 16)
@@ -268,6 +284,8 @@ jobs:
           CONFLICT_FULL_SHA: ${{ steps.cherry-pick.outputs.conflict_full_sha }}
           APPLIED_LINES: ${{ steps.cherry-pick.outputs.applied_lines }}
           EXCLUDED_LINES: ${{ steps.cherry-pick.outputs.excluded_lines }}
+          SKIPPED_LINES: ${{ steps.cherry-pick.outputs.skipped_lines }}
+          SKIPPED: ${{ steps.cherry-pick.outputs.skipped }}
           REMAINING_LINES: ${{ steps.cherry-pick.outputs.remaining_lines }}
           TARGET: ${{ matrix.target }}
           UPSTREAM: ${{ matrix.upstream }}
@@ -290,6 +308,12 @@ jobs:
               echo "$EXCLUDED_LINES"
               echo ""
               echo "_Excluded commits are configured in \`.github/upstream-sync-state.json\`._"
+              echo ""
+            fi
+
+            if [ "${SKIPPED:-0}" -gt 0 ]; then
+              echo "### ⏭️ Skipped — already applied (${SKIPPED})"
+              echo "$SKIPPED_LINES"
               echo ""
             fi
 
@@ -329,7 +353,7 @@ jobs:
             --draft
 
       - name: Report when first commit conflicts
-        if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied == '0'
+        if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied == '0' && steps.cherry-pick.outputs.conflict_full_sha != ''
         env:
           CONFLICT_FULL_SHA: ${{ steps.cherry-pick.outputs.conflict_full_sha }}
           CONFLICT_TITLE: ${{ steps.cherry-pick.outputs.conflict_title }}
@@ -359,6 +383,7 @@ jobs:
           COMMIT_COUNT: ${{ steps.find-commits.outputs.count || '0' }}
           APPLIED: ${{ steps.cherry-pick.outputs.applied || '0' }}
           EXCLUDED: ${{ steps.cherry-pick.outputs.excluded || '0' }}
+          SKIPPED: ${{ steps.cherry-pick.outputs.skipped || '0' }}
           TOTAL: ${{ steps.cherry-pick.outputs.total || '0' }}
           LAST_PROCESSED: ${{ steps.cherry-pick.outputs.last_processed || steps.sync-state.outputs.last_processed }}
           EXISTING_PR: ${{ steps.existing-pr.outputs.number }}
@@ -377,6 +402,9 @@ jobs:
             fi
             echo "| New commits found | ${COMMIT_COUNT} |"
             echo "| Applied this run | ${APPLIED} |"
+            if [ "${SKIPPED:-0}" -gt 0 ]; then
+              echo "| Skipped (already applied) | ${SKIPPED} |"
+            fi
             echo "| Excluded (configured) | ${EXCLUDED_COUNT} |"
             if [ -n "$EXISTING_PR" ]; then
               echo "| Status | ⏸️ Skipped — open PR #${EXISTING_PR} exists |"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -401,6 +401,7 @@ jobs:
           LAST_PROCESSED: ${{ steps.cherry-pick.outputs.last_processed || steps.sync-state.outputs.last_processed }}
           EXISTING_PR: ${{ steps.existing-pr.outputs.number }}
           EXCLUDED_COUNT: ${{ steps.sync-state.outputs.excluded_count || '0' }}
+          CONFLICT_SHA: ${{ steps.cherry-pick.outputs.conflict_sha || '' }}
         run: |
           {
             echo "## Sync Status: \`${UPSTREAM}\` → \`${TARGET}\`"

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -271,6 +271,19 @@ jobs:
             git commit -m "chore: update upstream sync state"
           fi
 
+      - name: Push state update when all commits were skipped
+        if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied == '0' && steps.cherry-pick.outputs.skipped != '0'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+          SYNC_BRANCH: ${{ steps.cherry-pick.outputs.branch }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          STATE_SHA=$(git rev-parse "$SYNC_BRANCH")
+          git checkout "$TARGET"
+          git cherry-pick --no-edit "$STATE_SHA"
+          git push origin "$TARGET"
+          echo "Pushed sync state update directly to ${TARGET} (all commits already applied)"
+
       - name: Push and create draft PR
         if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == '' && steps.cherry-pick.outputs.applied != '0'
         env:


### PR DESCRIPTION
## Summary
- Detect empty cherry-picks (already-applied patches) in the upstream sync workflow and skip them instead of treating them as merge conflicts
- Add tracking and reporting for skipped commits in PR body and status summary
- Fix "Report when first commit conflicts" step to only fire when there's an actual conflict
- Fix sync state persistence for all-skipped runs (state update is pushed directly to target branch)
- Fix missing CONFLICT_SHA in status summary env block

## Problem

When `git cherry-pick` produces an empty result (the changes already exist on the target branch), git exits non-zero. The workflow treated this identically to a real merge conflict — aborting the cherry-pick loop and blocking all subsequent commits. This caused all three sync jobs to fail on [run #26982560915](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/26982560915), even though two of the three "conflicts" were just already-applied patches.

## Changes

1. **Empty cherry-pick detection**: After `cherry-pick` fails, check `git diff --name-only --diff-filter=U` for unmerged files. If none exist, it's an empty cherry-pick — skip it with `git cherry-pick --skip` and continue processing
2. **Report step condition**: Added `conflict_full_sha != ''` check to prevent false failure when all commits are empty (no actual conflict)
3. **PR body**: Added "Skipped — already applied" section showing which commits were auto-skipped
4. **Status summary**: Added skipped count to the workflow run summary table and "All commits already applied" status
5. **Sync state persistence**: Updated "Update sync state" condition to also run for skipped-only runs, and added a dedicated step to push the state update directly to the target branch when no PR is needed
6. **CONFLICT_SHA env**: Added missing variable to the "Write status summary" step's env block so the conflict guard works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)