### PR TITLE
chore: exclude superseded golang.org/x/net bump from upstream sync (main)

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,6 +1,5 @@
 {
-  "last_processed_commit": "eee3bfdcb606701059bcd5d32d2b260674fae5e8",
+  "last_processed_commit": "7e909d27ca10de8170f5bc8730bad5f33803444d",
   "excluded_commits": {
-    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "golang.org/x/net v0.53.0 — already at v0.55.0 on main"
   }
 }

--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,4 +1,6 @@
 {
   "last_processed_commit": "eee3bfdcb606701059bcd5d32d2b260674fae5e8",
-  "excluded_commits": {}
+  "excluded_commits": {
+    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "golang.org/x/net v0.53.0 — already at v0.55.0 on main"
+  }
 }


### PR DESCRIPTION
## Summary
- Upstream commit `fb3a7a87` bumps `golang.org/x/net` to v0.53.0 to fix GO-2026-4918, but our `main` branch already has v0.55.0 (and newer transitive deps: x/crypto v0.52.0, x/mod v0.35.0, x/text v0.37.0)
- Cherry-picking this commit conflicts and would downgrade dependencies
- Adds the commit SHA to `excluded_commits` in `upstream-sync-state.json` so the sync workflow skips it

## Test plan
- [ ] Merge this PR
- [ ] Re-run the Upstream Sync workflow
- [ ] Verify the `release-1.23 → main` job advances past this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal synchronization state records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->