### PR TITLE
chore: exclude superseded Go toolchain bump from upstream sync (backplane-2.17)

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,6 +1,5 @@
 {
-  "last_processed_commit": "bf812a36dbbf0c91f2207d8d3f6452b16d3ff2d0",
+  "last_processed_commit": "7e909d27ca10de8170f5bc8730bad5f33803444d",
   "excluded_commits": {
-    "e88bd2e6db5118f9afabf81442d1692d02feb977": "Go toolchain v1.24.13 — already at go1.25.9 on backplane-2.17"
   }
 }

--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,4 +1,6 @@
 {
   "last_processed_commit": "bf812a36dbbf0c91f2207d8d3f6452b16d3ff2d0",
-  "excluded_commits": {}
+  "excluded_commits": {
+    "e88bd2e6db5118f9afabf81442d1692d02feb977": "Go toolchain v1.24.13 — already at go1.25.9 on backplane-2.17"
+  }
 }


### PR DESCRIPTION
## Summary
- Upstream commit `e88bd2e6` bumps Go toolchain to `go1.24.13`, but `backplane-2.17` already has `go 1.25.0` / `toolchain go1.25.9`
- Cherry-picking this commit would conflict and downgrade the toolchain
- Adds the commit SHA to `excluded_commits` in `upstream-sync-state.json` so the sync workflow skips it

## Test plan
- [ ] Merge this PR
- [ ] Re-run the Upstream Sync workflow
- [ ] Verify the `release-1.22 → backplane-2.17` job advances past this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)