### PR TITLE
chore: initialize upstream sync state for backplane-2.11

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,6 +1,4 @@
 {
-  "last_processed_commit": "",
-  "excluded_commits": {
-    "38ff4480368453708593c6d0b7c72d0644727ddd": "Bump Cluster API to v1.11.3 — already at v1.11.10 on backplane-2.11"
-  }
+  "last_processed_commit": "9d28438b3b9b9cdee74b87dd0b3c4cc4afd737ff",
+  "excluded_commits": {}
 }

--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,0 +1,6 @@
+{
+  "last_processed_commit": "",
+  "excluded_commits": {
+    "38ff4480368453708593c6d0b7c72d0644727ddd": "Bump Cluster API to v1.11.3 — already at v1.11.10 on backplane-2.11"
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `upstream-sync-state.json` on `backplane-2.11` with `last_processed_commit` set to `9d28438b` (Add xtrace debugging) — the last upstream commit on `release-1.22` already present after manual sync
- With the `git cherry` limit feature (#310), this reduces sync candidates from 35 to 2
- No `excluded_commits` needed — all superseded commits are before the limit

## Test plan
- [ ] Merge #310 (workflow change) first or together with this PR
- [ ] Re-run the Upstream Sync workflow
- [ ] Verify the `release-1.22 → backplane-2.11` job shows only 2 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)