### PR TITLE
fix: use last_processed_commit as git cherry limit in upstream sync

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -87,12 +87,12 @@ jobs:
         env:
           LAST_PROCESSED: ${{ steps.sync-state.outputs.last_processed }}
         run: |
-          CHERRY_ARGS="origin/${{ matrix.target }} upstream/${{ matrix.upstream }}"
+          CHERRY_ARGS=("origin/${{ matrix.target }}" "upstream/${{ matrix.upstream }}")
           if [ -n "$LAST_PROCESSED" ]; then
-            CHERRY_ARGS="$CHERRY_ARGS $LAST_PROCESSED"
+            CHERRY_ARGS+=("$LAST_PROCESSED")
             echo "Using limit: ${LAST_PROCESSED}"
           fi
-          mapfile -t ALL_COMMITS < <(git cherry $CHERRY_ARGS | awk '/^\+ / {print $2}')
+          mapfile -t ALL_COMMITS < <(git cherry "${CHERRY_ARGS[@]}" | awk '/^\+ / {print $2}')
           COMMITS=()
           MERGE_SKIPPED=0
           EXCLUDED_SKIPPED=0
@@ -143,7 +143,7 @@ jobs:
         if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == ''
         id: cherry-pick
         env:
-          LAST_PROCESSED_LIMIT: ${{ steps.sync-state.outputs.last_processed }}
+          LAST_PROCESSED: ${{ steps.sync-state.outputs.last_processed }}
         run: |
           DATE=$(date +%Y-%m-%d)
           BRANCH="upstream-sync/${{ matrix.target }}/${DATE}"
@@ -156,11 +156,11 @@ jobs:
           git checkout -b "$BRANCH"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-          CHERRY_ARGS="origin/${{ matrix.target }} upstream/${{ matrix.upstream }}"
-          if [ -n "$LAST_PROCESSED_LIMIT" ]; then
-            CHERRY_ARGS="$CHERRY_ARGS $LAST_PROCESSED_LIMIT"
+          CHERRY_ARGS=("origin/${{ matrix.target }}" "upstream/${{ matrix.upstream }}")
+          if [ -n "$LAST_PROCESSED" ]; then
+            CHERRY_ARGS+=("$LAST_PROCESSED")
           fi
-          mapfile -t SHAS < <(git cherry $CHERRY_ARGS | awk '/^\+ / {print $2}')
+          mapfile -t SHAS < <(git cherry "${CHERRY_ARGS[@]}" | awk '/^\+ / {print $2}')
           TOTAL=${#SHAS[@]}
           APPLIED=0
           EXCLUDED=0

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -84,8 +84,15 @@ jobs:
 
       - name: Find new upstream commits
         id: find-commits
+        env:
+          LAST_PROCESSED: ${{ steps.sync-state.outputs.last_processed }}
         run: |
-          mapfile -t ALL_COMMITS < <(git cherry origin/${{ matrix.target }} upstream/${{ matrix.upstream }} | awk '/^\+ / {print $2}')
+          CHERRY_ARGS="origin/${{ matrix.target }} upstream/${{ matrix.upstream }}"
+          if [ -n "$LAST_PROCESSED" ]; then
+            CHERRY_ARGS="$CHERRY_ARGS $LAST_PROCESSED"
+            echo "Using limit: ${LAST_PROCESSED}"
+          fi
+          mapfile -t ALL_COMMITS < <(git cherry $CHERRY_ARGS | awk '/^\+ / {print $2}')
           COMMITS=()
           MERGE_SKIPPED=0
           EXCLUDED_SKIPPED=0
@@ -135,6 +142,8 @@ jobs:
       - name: Cherry-pick commits
         if: steps.find-commits.outputs.count != '0' && steps.existing-pr.outputs.number == ''
         id: cherry-pick
+        env:
+          LAST_PROCESSED_LIMIT: ${{ steps.sync-state.outputs.last_processed }}
         run: |
           DATE=$(date +%Y-%m-%d)
           BRANCH="upstream-sync/${{ matrix.target }}/${DATE}"
@@ -147,7 +156,11 @@ jobs:
           git checkout -b "$BRANCH"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-          mapfile -t SHAS < <(git cherry origin/${{ matrix.target }} upstream/${{ matrix.upstream }} | awk '/^\+ / {print $2}')
+          CHERRY_ARGS="origin/${{ matrix.target }} upstream/${{ matrix.upstream }}"
+          if [ -n "$LAST_PROCESSED_LIMIT" ]; then
+            CHERRY_ARGS="$CHERRY_ARGS $LAST_PROCESSED_LIMIT"
+          fi
+          mapfile -t SHAS < <(git cherry $CHERRY_ARGS | awk '/^\+ / {print $2}')
           TOTAL=${#SHAS[@]}
           APPLIED=0
           EXCLUDED=0

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -89,8 +89,12 @@ jobs:
         run: |
           CHERRY_ARGS=("origin/${{ matrix.target }}" "upstream/${{ matrix.upstream }}")
           if [ -n "$LAST_PROCESSED" ]; then
-            CHERRY_ARGS+=("$LAST_PROCESSED")
-            echo "Using limit: ${LAST_PROCESSED}"
+            if git cat-file -e "${LAST_PROCESSED}^{commit}" 2>/dev/null; then
+              CHERRY_ARGS+=("$LAST_PROCESSED")
+              echo "Using limit: ${LAST_PROCESSED}"
+            else
+              echo "::warning::Ignoring invalid last_processed_commit: ${LAST_PROCESSED}"
+            fi
           fi
           mapfile -t ALL_COMMITS < <(git cherry "${CHERRY_ARGS[@]}" | awk '/^\+ / {print $2}')
           COMMITS=()
@@ -158,7 +162,11 @@ jobs:
 
           CHERRY_ARGS=("origin/${{ matrix.target }}" "upstream/${{ matrix.upstream }}")
           if [ -n "$LAST_PROCESSED" ]; then
-            CHERRY_ARGS+=("$LAST_PROCESSED")
+            if git cat-file -e "${LAST_PROCESSED}^{commit}" 2>/dev/null; then
+              CHERRY_ARGS+=("$LAST_PROCESSED")
+            else
+              echo "::warning::Ignoring invalid last_processed_commit: ${LAST_PROCESSED}"
+            fi
           fi
           mapfile -t SHAS < <(git cherry "${CHERRY_ARGS[@]}" | awk '/^\+ / {print $2}')
           TOTAL=${#SHAS[@]}


### PR DESCRIPTION
## Summary
- Passes `last_processed_commit` from `upstream-sync-state.json` as the `<limit>` argument to `git cherry`
- Only upstream commits **after** the last processed point are considered, making the field functional (previously informational only)
- Eliminates noise from old superseded commits on manually-synced branches (e.g., backplane-2.11 drops from 35 candidates to 2)
- When `last_processed_commit` is empty, falls back to the current behavior (no limit)
- Validates the SHA with `git cat-file -e` before use; logs a warning and skips the limit if invalid
- Uses bash arrays for safe argument construction (no word-splitting dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)