### PR TITLE
fix: exclude superseded x/net v0.53.0 bump from upstream sync (ARO-27589)

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,4 +1,6 @@
 {
   "last_processed_commit": "eee3bfdcb606701059bcd5d32d2b260674fae5e8",
-  "excluded_commits": {}
+  "excluded_commits": {
+    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "superseded: main already has x/net v0.55.0; this v0.53.0 bump conflicts"
+  }
 }


### PR DESCRIPTION
## Summary

Adds the superseded `golang.org/x/net` v0.53.0 bump (`fb3a7a87`) to `excluded_commits` in the upstream sync state, fixing the `release-1.23 → main` sync failure.

JIRA: https://redhat.atlassian.net/browse/ARO-27589

## Problem

The upstream sync [run #27104505760](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/27104505760/job/79991108742) failed for `(release-1.23, main)` because:

1. PR #307 set `last_processed_commit` to `7e909d27c` — a commit on **`upstream/release-1.22`**, not `release-1.23`
2. The workflow only fetches `upstream/release-1.23`, so `git cat-file -e` failed → warning logged, limit dropped
3. Without a limit, all upstream commits were processed; `fb3a7a870` (x/net v0.53.0) conflicted with main (which already has v0.55.0)
4. The "Push state update" step overwrote the manual advancement, reverting `last_processed_commit`

## Solution

Add `fb3a7a870592f1a7c75eaf2dff56652f2fa4a854` to `excluded_commits` in `.github/upstream-sync-state.json`. This is the correct mechanism — it works regardless of the `last_processed_commit` value, and the current value (`eee3bfdcb`) is valid on `upstream/release-1.23`.

After merging, re-running the sync workflow will:
- Skip `fb3a7a870` (excluded)
- Cherry-pick 4 pending commits cleanly (`c9a9cf901`, `36f5e0f36`, `c03eef644`, `e90380213`)
- Auto-skip 2 equivalent commits (`c59d18e78` x/crypto, `bcae20a0a` x/net v0.55.0)

## Changes

- `.github/upstream-sync-state.json` — added `fb3a7a870` to `excluded_commits` with reason

## Testing

- [x] Verified `eee3bfdcb` is a valid ancestor of `upstream/release-1.23`
- [x] Verified `fb3a7a870` is marked `+` by `git cherry` (needs exclusion, not auto-skipped)
- [x] Verified remaining 4 commits are `+` (will sync) and 2 are `-` (auto-skipped)
- [ ] Re-run upstream sync workflow after merge

Ref: ARO-27589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream synchronization configuration to exclude a commit due to dependency version conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->