### PR TITLE
fix: cherry-pick upstream 'harden git workflows' with conflict resolution

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
       with:
         egress-policy: audit
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Get Go version

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -20,6 +20,8 @@ jobs:
       with:
         egress-policy: audit
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      with:
+        persist-credentials: false
     - name: Get Go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -21,6 +21,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -19,7 +19,8 @@ jobs:
           - test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
-
+        with:
+          persist-credentials: false
       - name: Get Go version
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Check out code
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # tag=v6.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
       with:
         ref: ${{ matrix.branch }}
         persist-credentials: false

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # tag=v6.0.0
       with:
         ref: ${{ matrix.branch }}
+        persist-credentials: false
 
     - name: Capture scanned commit
       id: scanned-commit


### PR DESCRIPTION
## Summary

- Cherry-picks upstream commit `e903802131fc` ("harden git workflows") which adds `persist-credentials: false` to all `actions/checkout` steps — a security hardening that prevents the `GITHUB_TOKEN` from being stored in `.git/config` after checkout
- Resolves cherry-pick conflicts in `cover.yaml` and `weekly-security-scan.yaml` caused by divergent `actions/checkout` version pins (v6.0.0 vs v6.0.2)
- Bumps `actions/checkout` from v6.0.0 to v6.0.2 in both files to align with upstream and prevent future conflicts

## Context

The upstream sync workflow [run #27128645917](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/27128645917) failed because this commit conflicted on two workflow files where our `actions/checkout` was pinned to v6.0.0 while upstream had v6.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations across multiple pipelines to enhance security practices and reduce credential exposure.
  * Upgraded a GitHub Actions dependency version to benefit from improvements in the most recent patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->