### PR TITLE
chore: exclude already cherry-picked 'harden git workflows' from upstream sync

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,6 +1,7 @@
 {
   "last_processed_commit": "c03eef6448524e57acd66f184aa42764e396b264",
   "excluded_commits": {
-    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "superseded: main already has x/net v0.55.0; this v0.53.0 bump conflicts"
+    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "superseded: main already has x/net v0.55.0; this v0.53.0 bump conflicts",
+    "e903802131fc5bb0e4fb0194d3d55818b5c28234": "manually cherry-picked with conflict resolution in PR #312"
   }
 }


### PR DESCRIPTION
## Summary

- Adds upstream commit `e903802131fc` ("harden git workflows") to `excluded_commits` in the sync state file
- This commit was manually cherry-picked with conflict resolution in PR #312, but the sync state wasn't updated — causing the Upstream Sync workflow to repeatedly fail trying to cherry-pick it again

## Context

After PR #312 was merged, the Upstream Sync workflow still failed ([run 27131390722](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/27131390722)) because `git cherry` doesn't recognize the manually resolved cherry-pick (different SHA) as already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub workflow configuration to track upstream synchronization state.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->