### PR TITLE
ci: disable credential persistence in checkout steps

### DIFF
--- a/.github/workflows/dependabot-code-gen.yml
+++ b/.github/workflows/dependabot-code-gen.yml
@@ -33,6 +33,8 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # tag=v5.0.4
       name: Restore go cache
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to `actions/checkout` in `dependabot-code-gen.yml` and `dependency-review.yml`
- These were the only two workflows missing this hardening, flagged by CodeRabbit/zizmor in #319

## Context
Addresses CodeRabbit [finding](https://github.com/stolostron/cluster-api-provider-azure/pull/319/files#r2208117834) from PR #319. The `dependabot-code-gen` workflow is higher risk since it has `contents: write` permissions — `EndBug/add-and-commit` uses its own `github_token` input for pushing, so it does not depend on persisted checkout credentials.

## Test plan
- [ ] Verify `dependabot-code-gen` workflow still pushes generated code on dependabot branches
- [ ] Verify `dependency-review` workflow still runs on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow configurations to change credential handling behavior in automated checkout operations across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->