### PR TITLE
chore: exclude already cherry-picked CodeQL commit from upstream sync (ARO-27797)

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -3,6 +3,7 @@
   "excluded_commits": {
     "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "superseded: main already has x/net v0.55.0; this v0.53.0 bump conflicts",
     "e903802131fc5bb0e4fb0194d3d55818b5c28234": "manually cherry-picked with conflict resolution in PR #312",
-    "3ba5f1743f114fa28542193a410549bf4aeb45bf": "manually applied: fork workflows diverge; version bumps applied in sync-conflict resolution PR"
+    "3ba5f1743f114fa28542193a410549bf4aeb45bf": "manually applied: fork workflows diverge; version bumps applied in sync-conflict resolution PR",
+    "622b8554217c528970e6ffc04325b56c6b2f274d": "already cherry-picked as 57ea31898 in PR #305; re-applying conflicts with fork's codeql.yml"
   }
 }


### PR DESCRIPTION
## Summary
Excludes commit `622b8554` from the upstream sync so the release-1.23 → main sync can proceed.

JIRA: https://redhat.atlassian.net/browse/ARO-27797

## Problem
The [Upstream Sync workflow](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/27749107438) fails on the release-1.23 → main sync because commit `622b8554` ("ci: build Go with e2e tag for full CodeQL coverage") conflicts when cherry-picked.

This commit was already manually applied as `57ea31898` in PR #305 — re-applying it conflicts with the fork's divergent `codeql.yml`.

## Solution
Add `622b8554217c528970e6ffc04325b56c6b2f274d` to `excluded_commits` in `.github/upstream-sync-state.json`.

## Changes
- `.github/upstream-sync-state.json` — added the commit to the exclusion list with explanation

## Testing
- [x] JSON validated
- [x] No code changes — only sync metadata

Ref: ARO-27797

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal repository synchronization configuration.

---

**Note:** This release contains internal maintenance updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->