### PR TITLE
chore: enable pinDigests for Dockerfile in Renovate config (ARO-27798)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,7 @@
         "dockerfile"
       ],
       "enabled": true,
+      "pinDigests": true,
       "matchFileNames": [
         "stolostron/Dockerfile.stolostron"
       ]


### PR DESCRIPTION
## Summary
Configure Renovate to pin Docker image digests when updating tags in `stolostron/Dockerfile.stolostron`.

JIRA: https://redhat.atlassian.net/browse/ARO-27798

## Problem
Scorecard code-scanning alert [#50](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/50) flags that container images in `stolostron/Dockerfile.stolostron` are not pinned by hash. Since Renovate manages these image tags, any manual pin gets overwritten on the next update.

## Solution
Add `"pinDigests": true` to the Renovate package rule for `stolostron/Dockerfile.stolostron`. Future Renovate PRs will automatically include `@sha256:...` digest pins alongside the tag.

## Changes
- `renovate.json` — added `"pinDigests": true` to the Dockerfile package rule

## Testing
- [x] Valid JSON syntax
- [x] Renovate config schema compliant

Ref: ARO-27798

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image dependency management by enabling digest pinning for improved security and consistency in image deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->