### PR TITLE
chore: pin Docker images by digest in Dockerfile.stolostron (ARO-27798)

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1781070142 AS toolchain
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1781070142@sha256:430cd439ea3bb4af3727a843c0302594bb1973211ecbfc98e4450a40798075df AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} go build -o ./manager .
 
 # Copy the aso-controller into a thin image
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1781496985
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1781496985@sha256:1b99266db480e8aa6dfda6900697a07ec99334095b4f87d1687edfc06c965132
 COPY --from=builder /workspace/manager /manager
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary
Pin both Docker base images in `stolostron/Dockerfile.stolostron` by sha256 digest.

JIRA: https://redhat.atlassian.net/browse/ARO-27798

## Problem
Scorecard code-scanning alert [#50](https://github.com/stolostron/cluster-api-provider-azure/security/code-scanning/50) (medium severity) reports that container images are not pinned by hash, flagging the `Pinned-Dependencies` rule.

## Solution
Append `@sha256:...` digest to both `FROM` lines so images are pinned to exact builds.

## Changes
- `stolostron/Dockerfile.stolostron` line 1 — pinned `ubi9/go-toolset:9.8-1781070142` by digest
- `stolostron/Dockerfile.stolostron` line 29 — pinned `ubi9/ubi:9.8-1781496985` by digest

## Testing
- [x] Dockerfile syntax valid
- [x] Digests verified via `skopeo inspect`

Ref: ARO-27798

Generated with [Claude Code](https://claude.com/claude-code)