### PR TITLE
Upstream sync main ← release-1.23 (2026-06-19): 2/2 commits

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,9 +1,4 @@
 {
-  "last_processed_commit": "5533eaa6df3de2916f1debe8cc8a923444fd52c9",
-  "excluded_commits": {
-    "fb3a7a870592f1a7c75eaf2dff56652f2fa4a854": "superseded: main already has x/net v0.55.0; this v0.53.0 bump conflicts",
-    "e903802131fc5bb0e4fb0194d3d55818b5c28234": "manually cherry-picked with conflict resolution in PR #312",
-    "3ba5f1743f114fa28542193a410549bf4aeb45bf": "manually applied: fork workflows diverge; version bumps applied in sync-conflict resolution PR",
-    "622b8554217c528970e6ffc04325b56c6b2f274d": "already cherry-picked as 57ea31898 in PR #305; re-applying conflicts with fork's codeql.yml"
-  }
+  "last_processed_commit": "a9270d0ce639a3b2af1cd237737fb8c85bf63cb4",
+  "excluded_commits": {}
 }

--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -21,6 +21,10 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck source=hack/util.sh
 source "${REPO_ROOT}/hack/util.sh"
 
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-capz}"
+KIND="${KIND:-${REPO_ROOT}/hack/tools/bin/kind}"
+KUBECTL="${KUBECTL:-${REPO_ROOT}/hack/tools/bin/kubectl}"
+
 # Verify the required Environment Variables are present.
 capz::util::ensure_azure_envs
 
@@ -66,7 +70,35 @@ capz::util::generate_ssh_key
 echo "================ DOCKER BUILD ==============="
 PULL_POLICY=IfNotPresent make modules docker-build
 
+# cleanup_previous_attempt deletes any workload cluster and Azure RG left behind
+# by a previous create_cluster iteration, so retries start with a clean slate.
+cleanup_previous_attempt() {
+    local kind_kubeconfig="${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig"
+
+    if [[ -x "${KIND}" ]] && [[ -r "${kind_kubeconfig}" ]] && \
+       "${KIND}" get clusters 2>/dev/null | grep -qxF "${KIND_CLUSTER_NAME}"; then
+        echo "================ DELETE WORKLOAD CLUSTER (graceful) ==============="
+        if timeout 1200 "${KUBECTL}" --kubeconfig "${kind_kubeconfig}" \
+            delete cluster "${CLUSTER_NAME}" -n default --wait=true --ignore-not-found=true; then
+            return 0
+        fi
+        echo "Graceful cluster delete failed or timed out; falling back to az group delete"
+    fi
+
+    # Synchronous so attempt N+1 doesn't race a still-deleting RG.
+    if command -v az >/dev/null 2>&1 \
+        && [[ -n "${AZURE_RESOURCE_GROUP:-}" ]] \
+        && [[ "${AZURE_RESOURCE_GROUP}" == "${CLUSTER_NAME}" ]] \
+        && [[ "$(az group exists --name "${AZURE_RESOURCE_GROUP}" 2>/dev/null)" == "true" ]]; then
+        echo "================ AZURE RG CLEANUP (fallback) ==============="
+        timeout 1800 az group delete --name "${AZURE_RESOURCE_GROUP}" --yes \
+            || echo "WARNING: az group delete failed; subsequent attempt may see leftover Azure resources"
+    fi
+}
+
 create_cluster() {
+    cleanup_previous_attempt
+
     echo "================ MAKE CLEAN ==============="
     make clean
 

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -171,9 +171,17 @@ create_cluster() {
 wait_for_nodes() {
   echo "Waiting for ${CONTROL_PLANE_MACHINE_COUNT} control plane machine(s), ${WORKER_MACHINE_COUNT} worker machine(s), ${WINDOWS_WORKER_MACHINE_COUNT:-0} windows machine(s), and ${MONITORING_MACHINE_COUNT} monitoring machine(s) to become Ready"
 
-    # Ensure that all nodes are registered with the API server before checking for readiness
-    local total_nodes="$((CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT + WINDOWS_WORKER_MACHINE_COUNT + MONITORING_MACHINE_COUNT))"
-    while [[ $("${KUBECTL}" get nodes -ojson | jq '.items | length') -ne "${total_nodes}" ]]; do
+    # EXPECTED_NODE_COUNT is set by install_addons from the actual CAPI replicas.
+    # Fall back to the machine count env vars if unset or it could not be computed.
+    local total_nodes="${EXPECTED_NODE_COUNT:-0}"
+    if [[ "${total_nodes}" -le 0 ]]; then
+        total_nodes="$((CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT + WINDOWS_WORKER_MACHINE_COUNT + MONITORING_MACHINE_COUNT))"
+    fi
+
+    # Wait for at least total_nodes to register. -lt (not an exact match) avoids
+    # hanging when a template defines both a MachineDeployment and a MachinePool.
+    echo "Waiting for at least ${total_nodes} node(s) to become Ready"
+    while [[ $("${KUBECTL}" get nodes -ojson | jq '.items | length') -lt "${total_nodes}" ]]; do
         sleep 10
     done
 
@@ -207,6 +215,18 @@ install_addons() {
     # In order to determine the successful outcome of CNI and cloud-provider-azure,
     # we need to wait a little bit for nodes and pods terminal state,
     # so we block successful return upon the cluster being fully operational.
+
+    # Derive the expected node count from the actual CAPI replicas (KCP +
+    # MachineDeployments + MachinePools). The CONTROL_PLANE/WORKER_MACHINE_COUNT
+    # formula undercounts templates with both a MachineDeployment and a MachinePool,
+    # since each consumes WORKER_MACHINE_COUNT (e.g. dual-stack and ipv6).
+    EXPECTED_NODE_COUNT=$("${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" \
+        get kubeadmcontrolplanes.v1beta1.controlplane.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io,machinepools.v1beta1.cluster.x-k8s.io \
+        -A -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" \
+        -o jsonpath='{range .items[*]}{.spec.replicas}{"\n"}{end}' 2>/dev/null \
+        | awk '{sum += $1} END {print sum + 0}') || EXPECTED_NODE_COUNT=0
+    export EXPECTED_NODE_COUNT
+
     export -f wait_for_nodes
     timeout --foreground 1800 bash -c wait_for_nodes
     export -f wait_for_pods


### PR DESCRIPTION
## Upstream Sync — 2026-06-19

Applied **2/2** commits from [kubernetes-sigs/cluster-api-provider-azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure) `release-1.23` into `main`.

### Applied
- `20f7b0b9` fix: clean up Azure resources between create-dev-cluster.sh retries
- `a9270d0c` CI: count MachinePool replicas when waiting for workload cluster nodes

### 🚫 Excluded (1)
- `622b8554` ci: build Go with e2e tag for full CodeQL coverage

_Excluded commits are configured in `.github/upstream-sync-state.json`._

### Sync state update
- Advanced `last_processed_commit` to `a9270d0c`
- Cleared `excluded_commits` — all 4 entries are now behind the cursor and will never be matched again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev cluster creation with automatic cleanup of previous attempts to enable reliable retries.
  * Enhanced node readiness detection in CI pipelines to dynamically accommodate cluster scaling.

* **Chores**
  * Updated upstream synchronization tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->