### PR TITLE
Upstream sync main ← release-1.23 (2026-06-22): 1/1 commits

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,4 +1,4 @@
 {
-  "last_processed_commit": "a9270d0ce639a3b2af1cd237737fb8c85bf63cb4",
+  "last_processed_commit": "d5e8ac84d831d9a7fcee15b5c9d3010aeb99aa1c",
   "excluded_commits": {}
 }

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -277,7 +277,7 @@ if [[ ! "${CLUSTER_TEMPLATE}" =~ "aks" ]]; then
   install_addons
 fi
 
-"${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" wait -A --for=condition=Ready --timeout=10m -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" machinepools.v1beta1.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io
+"${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" wait -A --for=condition=Ready --timeout=20m -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" machinepools.v1beta1.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io
 
 echo "Cluster ${CLUSTER_NAME} created and fully operational"
 


### PR DESCRIPTION
## Upstream Sync — 2026-06-22

Applied **1/1** commits from [kubernetes-sigs/cluster-api-provider-azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure) `release-1.23` into `main`.

### Applied
- `d5e8ac84` fix: increase MachineDeployment Ready condition timeout from 10m to 20m

### Sync state update
- Advanced `last_processed_commit` to `d5e8ac84`

> **Note:** Created manually because the automated Upstream Sync workflow failed with a 403 on push ([run #27945754283](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/27945754283)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream synchronization tracking state.
  * Extended CI pipeline timeout for workload cluster resource readiness to 20 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->