### PR TITLE
Update CodeRabbit config: add IDE & AI tool configuration supply chain rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -194,6 +194,24 @@ reviews:
         - Agentic CI actions: audit for prompt injection via
           issue/PR title/body flowing into LLM prompts
 
+    # ── IDE & AI tool configuration (supply chain risk) ─────────
+    - path: "**/{.claude,.vscode}/**/*"
+      instructions: |
+        HIGH RISK — IDE and AI tool configuration (prodsec-skills):
+        These directories can be supply chain attack vectors.
+        Review every change with a security and malware lens.
+        Flag the following for close scrutiny:
+        - .claude: hook commands, MCP server definitions, or
+          permissive tool-use policies in settings.json
+        - .claude: any scripts or binaries (e.g., .mjs, .sh)
+        - .vscode: tasks.json or launch.json entries that execute
+          code on folder open, build, or save
+        - .vscode: settings.json entries that auto-run formatters,
+          linters, or extensions with broad permissions
+        - Any change that grants broad filesystem or network access
+        - Obfuscated content or suspiciously large files
+        - Changes without a clear, legitimate purpose
+
     # ── Authentication & OAuth ───────────────────────────────────
     - path: "**/{auth,oauth,oidc,login,session,saml}/**/*"
       instructions: |


### PR DESCRIPTION
## Summary
Adopt [prodsec-skills#31](https://github.com/RedHatProductSecurity/prodsec-skills/pull/31) — adds a CodeRabbit path instruction that flags `.claude/` and `.vscode/` directories as high-risk supply chain attack vectors.

Jira: [ARO-28015](https://redhat.atlassian.net/browse/ARO-28015)

[ARO-28015]: https://redhat.atlassian.net/browse/ARO-28015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added stricter review guidance for AI and IDE configuration folders.
  * Highlighted higher-risk patterns such as hooks, tool definitions, scripts, launch/task behavior, auto-running extensions, broad filesystem or network access, and unusually large or obscured files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->