### PR TITLE
ci: bump codecov-action v5.5.2 → v7.0.0 (backplane-2.17)

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -26,7 +26,7 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
-#     - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+#     - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 #       env:
 #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 #       with:


### PR DESCRIPTION
## Summary
- Cherry-picks upstream commit `0918f4e13` onto backplane-2.17
- Resolves cherry-pick conflict: keeps codecov-action commented out (backplane-specific) while updating the hash from v5.5.2 to v7.0.0
- Unblocks the upstream sync workflow ([run #28937529105](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/28937529105))

🤖 Generated with [Claude Code](https://claude.ai/claude-code)