### PR TITLE
ci: advance upstream sync state past manually applied commits

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,5 +1,5 @@
 {
-  "last_processed_commit": "7e909d27ca10de8170f5bc8730bad5f33803444d",
+  "last_processed_commit": "b5ead83195d85660b558e3c5a46743585e5bb0a6",
   "excluded_commits": {
   }
 }


### PR DESCRIPTION
## Summary
- Advances `last_processed_commit` in `.github/upstream-sync-state.json` to `b5ead831` (tip of upstream `release-1.22`)
- The codecov-action bump (`0918f4e13`) and CVE fixes (`7d54fd53`, `f3af6aa5`) were cherry-picked manually via PRs #358, #349, #347 but `last_processed_commit` was not updated
- This caused the upstream sync workflow to repeatedly conflict on already-applied changes

## Test plan
- [ ] Re-run the [Upstream Sync workflow](https://github.com/stolostron/cluster-api-provider-azure/actions/workflows/upstream-sync.yml) after merge — the `backplane-2.17` job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)