### PR TITLE
fix: add .trivyignore to suppress false-positive security scan failure

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# GO-2026-5932: golang.org/x/crypto/openpgp is unmaintained and unsafe by design.
+# This is a transitive dependency with UNKNOWN severity and no fix available.
+# It causes false-positive failures in the weekly security scan because Trivy
+# exits non-zero on UNKNOWN-severity advisories even when the severity filter
+# is set to CRITICAL,HIGH,MEDIUM,LOW.
+GO-2026-5932


### PR DESCRIPTION
## Summary

Adds a `.trivyignore` file to suppress advisory GO-2026-5932 which causes false-positive failures in the weekly Trivy security scan.

JIRA: https://redhat.atlassian.net/browse/ARO-28247

## Problem

The weekly security scan ([run 29004215176](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/29004215176)) fails on all three branches (main, backplane-2.17, backplane-2.11) due to a mismatch between Trivy's exit code behavior and the workflow's severity filter:

1. Trivy finds advisory **GO-2026-5932** — `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design. Severity: **UNKNOWN** (no fix available).
2. The workflow sets `exit-code: 1`, so Trivy exits non-zero on *any* finding — including UNKNOWN-severity advisories.
3. The SARIF counter and human-readable output both correctly report **0 vulnerabilities** (they filter by CRITICAL/HIGH/MEDIUM/LOW).
4. But the "Fail if vulnerabilities found" step checks `steps.trivy-scan.outcome == 'failure'` — so the job fails despite no actual vulnerabilities matching the configured severity filter.

## Solution

Add a `.trivyignore` file at the repo root containing `GO-2026-5932`. This is the cleanest approach because:
- The advisory is informational with no fix version available
- `golang.org/x/crypto/openpgp` is a transitive dependency (not used directly in the codebase)
- The `.trivyignore` file is explicit and auditable

## Changes

- `.trivyignore` — new file suppressing GO-2026-5932

## Testing

- The weekly security scan will pass on the next scheduled or manual run
- No code changes, only Trivy scan configuration

Ref: ARO-28247

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced recurring security scan noise by adding an exception for a known false positive, helping scans complete more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->