### PR TITLE
fix: add .trivyignore to suppress false-positive security scan failure (backplane-2.17)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# GO-2026-5932: golang.org/x/crypto/openpgp is unmaintained and unsafe by design.
+# This is a transitive dependency with UNKNOWN severity and no fix available.
+# It causes false-positive failures in the weekly security scan because Trivy
+# exits non-zero on UNKNOWN-severity advisories even when the severity filter
+# is set to CRITICAL,HIGH,MEDIUM,LOW.
+GO-2026-5932


### PR DESCRIPTION
## Summary

Backport of #364 to backplane-2.17. Adds `.trivyignore` to suppress GO-2026-5932 (UNKNOWN-severity advisory on `golang.org/x/crypto/openpgp`) which causes false-positive weekly security scan failures.

JIRA: https://redhat.atlassian.net/browse/ARO-28247

## Changes

- `.trivyignore` — new file suppressing GO-2026-5932

See #364 for full analysis.

Ref: ARO-28247

Generated with [Claude Code](https://claude.com/claude-code)