### PR TITLE
fix: handle Konflux build cancellations in pr-capi-tests workflow (ARO-28392)

### DIFF
--- a/.github/workflows/pr-capi-tests.yaml
+++ b/.github/workflows/pr-capi-tests.yaml
@@ -74,6 +74,8 @@ jobs:
           REPO="$GH_REPO"
           MAX_ATTEMPTS=60
           POLL_INTERVAL=60
+          MAX_CANCEL_RETRIES=15
+          CANCEL_RETRIES=0
 
           echo "Waiting for Konflux check '${CHECK_NAME}' on commit ${SHA}..."
 
@@ -81,7 +83,7 @@ jobs:
           CONCLUSION=""
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             RESULT=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" \
-              --jq ".check_runs[] | select(.name == \"${CHECK_NAME}\") | {status, conclusion}" \
+              --jq "[.check_runs[] | select(.name == \"${CHECK_NAME}\")] | sort_by(.started_at) | last | {status, conclusion}" \
               2>/dev/null || echo "")
 
             if [ -z "$RESULT" ]; then
@@ -97,6 +99,15 @@ jobs:
               if [ "$CONCLUSION" = "success" ]; then
                 echo "Konflux build succeeded!"
                 break
+              elif [ "$CONCLUSION" = "cancelled" ]; then
+                CANCEL_RETRIES=$((CANCEL_RETRIES + 1))
+                if [ "$CANCEL_RETRIES" -ge "$MAX_CANCEL_RETRIES" ]; then
+                  echo "::error::Konflux build was cancelled ${CANCEL_RETRIES} times (likely throttled). Re-push or manually re-trigger the Konflux check."
+                  exit 1
+                fi
+                echo "Attempt ${i}/${MAX_ATTEMPTS}: Konflux build cancelled (${CANCEL_RETRIES}/${MAX_CANCEL_RETRIES}), waiting for re-queue..."
+                STATUS=""
+                CONCLUSION=""
               else
                 echo "::error::Konflux build finished with conclusion: ${CONCLUSION}"
                 exit 1

--- a/.github/workflows/pr-capi-tests.yaml
+++ b/.github/workflows/pr-capi-tests.yaml
@@ -83,7 +83,7 @@ jobs:
           CONCLUSION=""
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             RESULT=$(gh api "repos/${REPO}/commits/${SHA}/check-runs" \
-              --jq "[.check_runs[] | select(.name == \"${CHECK_NAME}\")] | sort_by(.started_at) | last | {status, conclusion}" \
+              --jq "[.check_runs[] | select(.name == \"${CHECK_NAME}\")] | sort_by(.id) | last // empty | {status, conclusion}" \
               2>/dev/null || echo "")
 
             if [ -z "$RESULT" ]; then


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes two reliability issues in the Konflux build polling loop:

- **Pick the newest run by `id`**: When multiple check runs share the same name
  (e.g., after a cancellation and re-queue), the loop now sorts by `id` — a
  monotonically increasing integer — and takes the last entry. The previous
  `sort_by(.started_at)` was unreliable because a freshly queued run has
  `started_at: null`, and jq sorts null before non-null values, causing the old
  cancelled run to win the sort.
- **Empty-match guard with `// empty`**: Added `// empty` after `last` so an
  empty match array produces no output instead of `{"status":null,"conclusion":null}`,
  preserving the "check not found yet" polling path.
- **Cancellation retry budget**: Retries `cancelled` conclusions up to 15 times
  (≈ 15 min at 60 s poll interval) before failing. Konflux throttles parallel
  builds by cancelling and re-queuing them, so a single throttle-cancel should
  never block a PR with no actionable error.

**Which issue(s) this PR fixes**:

JIRA: https://redhat.atlassian.net/browse/ARO-28392

**Special notes for your reviewer**:

CI-only change — modifies only the `.github/workflows/pr-capi-tests.yaml` polling logic. No production code affected.

**TODOs**:

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)