### PR TITLE
Upstream sync main ← release-1.23 (2026-07-20)

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,4 +1,4 @@
 {
-  "last_processed_commit": "71bf10eb7bbdd3bffa41188e20368b839554361c",
+  "last_processed_commit": "dda021d8a0a5113abf8580241266e8db0e7cf7aa",
   "excluded_commits": {}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 // Workaround for prometheus/common v0.66.0+ breaking change that causes panic
 // in cluster-api test framework's TextParser usage. Pin prometheus dependencies

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.25.11
+  minimum_go_version=go1.25.12
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260617165044-85c17a5f1026
 


### PR DESCRIPTION
Automated upstream sync from `release-1.23` into `main`.

## Commits

- Bump Go toolchain to v1.25.12

## Notes

This PR was created manually after the [Upstream Sync GHA workflow](https://github.com/stolostron/cluster-api-provider-azure/actions/runs/29731534834) failed at the `gh pr create` step due to a token permission issue (tracked in ARO-28518). The branch was pushed successfully; only the PR creation failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain to version 1.25.12.
  * Aligned development and build tooling with the updated Go version.
  * Improved consistency when validating the installed Go environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->