### PR TITLE
fix: add MCE version to CAPZ User-Agent header (ARO-24154)

### DIFF
--- a/.tekton/cluster-api-provider-azure-mce-50-pull-request.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-50-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}]'
+  - name: build-args
+    value:
+    - GIT_COMMIT={{revision}}
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/cluster-api-provider-azure-mce-51-pull-request.yaml
+++ b/.tekton/cluster-api-provider-azure-mce-51-pull-request.yaml
@@ -42,6 +42,9 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}]'
+  - name: build-args
+    value:
+    - GIT_COMMIT={{revision}}
   pipelineRef:
     resolver: git
     params:

--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -11,6 +11,9 @@ WORKDIR /workspace
 
 ENV GOFLAGS="-buildvcs=false"
 
+ARG MCE_VERSION=dev
+ARG GIT_COMMIT=unknown
+
 COPY ./ ./
 
 # Cache deps before building and copying source so that we don't need to re-download as much
@@ -23,7 +26,10 @@ RUN  --mount=type=cache,target=/root/.local/share/golang \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} go build -o ./manager .
+    SHORT_COMMIT=$(echo "${GIT_COMMIT}" | cut -c1-7) && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} \
+    go build -ldflags "-X 'sigs.k8s.io/cluster-api-provider-azure/version.gitVersion=${MCE_VERSION}-${SHORT_COMMIT}'" \
+    -o ./manager .
 
 # Copy the aso-controller into a thin image
 FROM registry.access.redhat.com/ubi9/ubi:9.8-1785388874@sha256:aecc1f893388841178ce0276e2f7b087e63e1e4521ec86a96d9c9416c6d419fa

--- a/stolostron/Makefile
+++ b/stolostron/Makefile
@@ -5,4 +5,4 @@ IMG_TAG ?= latest
 IMG ?= ${IMG_REG}/${IMG_REPO}/${IMG_NAME}:${IMG_TAG}
 
 docker-build:
-	docker build -f Dockerfile.stolostron ../ -t ${IMG}
+	docker build -f Dockerfile.stolostron --build-arg GIT_COMMIT=$$(git rev-parse --short HEAD 2>/dev/null || echo unknown) ../ -t ${IMG}


### PR DESCRIPTION
## Summary

- Add `MCE_VERSION` build-arg to the stolostron Dockerfile and embed it with the git commit hash into the binary via ldflags
- Produces `User-Agent: cluster-api-provider-azure/{MCE_VERSION}-{commit}` in all Azure HTTP requests
- Fixes empty version string in User-Agent that made it hard to identify CAPZ as the source of ARM requests during incidents (AROSLSRE-720)

Jira: [ARO-24154](https://issues.redhat.com/browse/ARO-24154)

## Test plan

- [ ] Verify the stolostron Docker image builds successfully
- [ ] Confirm the built binary reports correct version via User-Agent header
- [ ] Check ARM request logs show `cluster-api-provider-azure/main-<commit>` in User-Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-24154]: https://redhat.atlassian.net/browse/ARO-24154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build version tracking by including the release version and Git commit identifier in application metadata.
  * Builds without an available commit identifier now use a clear fallback value.
  * Version information is more consistent across local and automated builds, making deployments easier to identify and troubleshoot.

* **Bug Fixes**
  * Azure deployments can now use a custom Resource Manager endpoint through configuration, improving support for non-default Azure environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->