### PR TITLE
docs: add downstream fork context index (docs/DOWNSTREAM.md) (ARO-29087)

### DIFF
--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -1,0 +1,75 @@
+# Downstream context (stolostron / ARO-HCP)
+
+Entry point for AI coding agents (and new humans) working in the
+**stolostron** fork of Cluster API Provider Azure (CAPZ).
+
+This file is a **table of contents**, not a manual. It describes only what is
+*specific to this fork* and points at the authoritative docs for everything
+else — it does not duplicate them. Read the linked document for detail before
+making changes.
+
+> **This is a downstream fork.** The engineering source of truth — architecture,
+> build/test commands, controller patterns, code generation — lives in the
+> upstream-maintained docs in this repo. Start with
+> [`AGENTS.md`](../AGENTS.md) (the full CAPZ agent manual, synced from upstream)
+> and [`README.md`](../README.md). This page adds only the stolostron/ARO-HCP
+> layer on top.
+
+## What this fork is
+
+`stolostron/cluster-api-provider-azure` is a downstream fork of the upstream
+project [`kubernetes-sigs/cluster-api-provider-azure`](https://github.com/kubernetes-sigs/cluster-api-provider-azure).
+It packages CAPZ for **Azure Red Hat OpenShift Hosted Control Planes (ARO-HCP)**
+and ships it as part of **multicluster engine (MCE) / backplane** via
+[Konflux](https://konflux-ci.dev/) builds.
+
+The Go module path stays `sigs.k8s.io/cluster-api-provider-azure` — this fork
+does not rename the module.
+
+## How it differs from upstream
+
+The Go source is kept as close to upstream as possible; the downstream-only
+pieces are the release-branch model, the automated upstream sync, and the
+Konflux build/pipeline configuration.
+
+| Concern | Where it lives | Notes |
+|---------|----------------|-------|
+| Automated upstream sync | [`.github/workflows/upstream-sync.yml`](../.github/workflows/upstream-sync.yml) | Weekly (Mon 08:17 UTC) + manual dispatch. Opens draft PRs that merge upstream release branches into the downstream branches. |
+| Konflux build pipelines | [`.tekton/`](../.tekton) | Tekton `PipelineRun` definitions for MCE releases (`mce-217`, `mce-51`, `mce-50`), split into `-pull-request` and `-push` variants. |
+| Release branches | see sync matrix below | Downstream branches track specific upstream release branches. |
+
+### Branch model
+
+| Downstream branch | Tracks upstream | Ships in |
+|-------------------|-----------------|----------|
+| `main` | `release-1.23` | MCE dev / next |
+| `backplane-2.17` | `release-1.22` | MCE 2.17 |
+| `backplane-2.11` | `release-1.22` | MCE 2.11 |
+
+The authoritative matrix is the `strategy.matrix` in
+[`upstream-sync.yml`](../.github/workflows/upstream-sync.yml) — consult it there
+rather than trusting this table if they disagree.
+
+### Working with the fork
+
+- **Keep changes upstream-friendly.** Prefer contributing fixes upstream and
+  letting them flow down via the sync. Downstream-only patches make every future
+  sync harder to merge.
+- **Do not edit upstream-tracked files to add downstream notes.** Files such as
+  [`AGENTS.md`](../AGENTS.md), [`CLAUDE.md`](../CLAUDE.md), [`README.md`](../README.md),
+  and [`CONTRIBUTING.md`](../CONTRIBUTING.md) are synced from upstream; edits to
+  them create recurring merge conflicts. Put downstream-specific context here
+  instead.
+- **PR target.** Open PRs against the appropriate downstream branch
+  (`main` / `backplane-2.17` / `backplane-2.11`), not against upstream.
+
+## Start here
+
+| Document | What it covers |
+|----------|----------------|
+| [AGENTS.md](../AGENTS.md) | **Upstream CAPZ agent manual** — architecture, dev/build/test commands, controller & service patterns, code generation, testing strategy. The primary source of truth. |
+| [CLAUDE.md](../CLAUDE.md) | Claude Code entry point (defers to `AGENTS.md`). |
+| [README.md](../README.md) | Project overview, prerequisites, quick start. |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Upstream contribution workflow and conventions. |
+| [docs/README.md](README.md) | Documentation index (links into the CAPZ book at capz.sigs.k8s.io). |
+| [SECURITY.md](../SECURITY.md) / [SUPPORT.md](../SUPPORT.md) | Vulnerability reporting and support channels. |

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -43,14 +43,18 @@ Konflux build/pipeline configuration.
 | Downstream branch | Tracks upstream | Ships in |
 |-------------------|-----------------|----------|
 | `main` | `main` | MCE 5.1 dev; PRs also trigger the `mce-51` Konflux build |
-| `backplane-5.1` | `main` (via `main` sync) | MCE 5.1 |
-| `backplane-5.0` | `release-1.26` (via `release-1.26` sync) | MCE 5.0 |
+| `backplane-5.1` | `main` (fast-forwarded from `main`) | MCE 5.1 |
+| `backplane-5.0` | `release-1.26` (fast-forwarded from `release-1.26`) | MCE 5.0 |
 | `backplane-2.17` | `release-1.22` | MCE 2.17 |
 | `backplane-2.11` | `release-1.22` | MCE 2.11 |
 
-Intermediate sync branches (`release-1.23`, `release-1.26`) exist solely to
-receive upstream syncs and are merged into the corresponding shipping branches
-— they are not development targets.
+Sync-only branches receive upstream syncs but are not development targets:
+
+- `release-1.26` is fast-forwarded into `backplane-5.0` (the MCE 5.0 shipping
+  branch) by [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml) on push.
+- `release-1.23` is synced from upstream to feed a downstream ACM build whose
+  pipeline is defined outside this repo; it has no in-repo Konflux pipeline or
+  shipping branch here.
 
 The authoritative matrix is the `strategy.matrix` in
 [`upstream-sync.yml`](../.github/workflows/upstream-sync.yml) — consult it there

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -42,9 +42,15 @@ Konflux build/pipeline configuration.
 
 | Downstream branch | Tracks upstream | Ships in |
 |-------------------|-----------------|----------|
-| `main` | `release-1.23` | MCE dev / next |
+| `main` | `main` | MCE 5.1 dev; PRs also trigger the `mce-51` Konflux build |
+| `backplane-5.1` | `main` (via `main` sync) | MCE 5.1 |
+| `backplane-5.0` | `release-1.26` (via `release-1.26` sync) | MCE 5.0 |
 | `backplane-2.17` | `release-1.22` | MCE 2.17 |
 | `backplane-2.11` | `release-1.22` | MCE 2.11 |
+
+Intermediate sync branches (`release-1.23`, `release-1.26`) exist solely to
+receive upstream syncs and are merged into the corresponding shipping branches
+— they are not development targets.
 
 The authoritative matrix is the `strategy.matrix` in
 [`upstream-sync.yml`](../.github/workflows/upstream-sync.yml) — consult it there
@@ -61,7 +67,8 @@ rather than trusting this table if they disagree.
   them create recurring merge conflicts. Put downstream-specific context here
   instead.
 - **PR target.** Open PRs against the appropriate downstream branch
-  (`main` / `backplane-2.17` / `backplane-2.11`), not against upstream.
+  (`main` / `backplane-5.1` / `backplane-5.0` / `backplane-2.17` / `backplane-2.11`),
+  not against upstream.
 
 ## Start here
 

--- a/docs/DOWNSTREAM.md
+++ b/docs/DOWNSTREAM.md
@@ -43,7 +43,7 @@ Konflux build/pipeline configuration.
 | Downstream branch | Tracks upstream | Ships in |
 |-------------------|-----------------|----------|
 | `main` | `main` | MCE 5.1 dev; PRs also trigger the `mce-51` Konflux build |
-| `backplane-5.1` | `main` (fast-forwarded from `main`) | MCE 5.1 |
+| `backplane-5.1` | `main` (fast-forwarded from `main` by [`ffwd-branch.yaml`](../.github/workflows/ffwd-branch.yaml)) | MCE 5.1 |
 | `backplane-5.0` | `release-1.26` (fast-forwarded from `release-1.26`) | MCE 5.0 |
 | `backplane-2.17` | `release-1.22` | MCE 2.17 |
 | `backplane-2.11` | `release-1.22` | MCE 2.11 |


### PR DESCRIPTION
## Description

Contextification Phase 2 (ARO-29087) asks each CAPZ downstream repo to make its
prescriptive context discoverable to people and AI agents.

Unlike the reference repos, this repo is a **downstream fork** of
kubernetes-sigs/cluster-api-provider-azure and already carries the upstream
`AGENTS.md` (the full CAPZ agent manual) and `CLAUDE.md` (a thin pointer to it),
both synced from upstream. Overwriting those with a thin index would delete
upstream content and cause recurring `upstream-sync.yml` merge conflicts.

Instead, this PR adds a **separate** downstream index that leaves all
upstream-tracked files untouched.

JIRA: https://redhat.atlassian.net/browse/ARO-29087

## Changes Made

- Add `docs/DOWNSTREAM.md` — a thin, vendor-neutral table of contents describing
  what is specific to this stolostron/ARO-HCP fork:
  - what the fork is for (ARO-HCP / MCE packaging of CAPZ)
  - how it differs from upstream
  - the automated upstream sync (`.github/workflows/upstream-sync.yml`)
  - the Konflux build pipelines (`.tekton/`)
  - the release-branch model (main / backplane-2.17 / backplane-2.11)
  - defers to `AGENTS.md`, `README.md`, `CONTRIBUTING.md` for everything else.

## Files NOT changed (deliberately)

`AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md` — all upstream-tracked;
left untouched to avoid destroying upstream content and to keep upstream sync
clean.

## Additional Notes

Docs-only change; no Go code, tests, or upstream files affected. All internal
markdown links were verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for downstream fork maintainers, including branch management, upstream synchronization, release processes, contribution practices, and relevant project resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->