### PR TITLE
add .github/CODEOWNERS (backplane-2.17)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+# @RadekCap, @marek-veber and @mzazrivec will be requested for
+# review when someone opens a pull request
+*       @RadekCap @marek-veber @mzazrivec


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file to match stolostron/azure-service-operator
- Required for GitHub ruleset codeowner review enforcement

## Test plan
- [x] Verify CODEOWNERS file matches ASO pattern with correct team members

🤖 Generated with [Claude Code](https://claude.com/claude-code)