### PR TITLE
Upstream sync backplane-2.17 ← release-1.22 (2026-08-24): 1/1 commits

### DIFF
--- a/.github/upstream-sync-state.json
+++ b/.github/upstream-sync-state.json
@@ -1,5 +1,4 @@
 {
-  "last_processed_commit": "b5ead83195d85660b558e3c5a46743585e5bb0a6",
-  "excluded_commits": {
-  }
+  "last_processed_commit": "68e07b659ab1c41078a6277a2e6aee455bd9be23",
+  "excluded_commits": {}
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -118,16 +118,56 @@ func WaitForDeploymentsAvailable(ctx context.Context, input WaitForDeploymentsAv
 func GetWaitForDeploymentsAvailableInput(ctx context.Context, clusterProxy framework.ClusterProxy, name, namespace string, specName string) WaitForDeploymentsAvailableInput {
 	Expect(clusterProxy).NotTo(BeNil())
 	cl := clusterProxy.GetClient()
+	clientset := clusterProxy.GetClientSet()
 	var d = &appsv1.Deployment{}
 	Eventually(func() error {
 		return cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, d)
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
-	clientset := clusterProxy.GetClientSet()
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed(), func() string {
+		return describeDeploymentsInNamespace(ctx, clientset, namespace, name)
+	})
 	return WaitForDeploymentsAvailableInput{
 		Deployment: d,
 		Clientset:  clientset,
 		Getter:     cl,
 	}
+}
+
+// describeDeploymentsInNamespace returns a string summarizing the deployments and pods that do exist
+// in the given namespace, to help debug why an expected deployment never showed up (e.g. when its
+// Helm chart install via CAAPH failed).
+func describeDeploymentsInNamespace(ctx context.Context, clientset *kubernetes.Clientset, namespace, name string) string {
+	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("Deployment %s/%s never appeared", namespace, name))
+	if clientset == nil {
+		b.WriteString("\nclientset is nil, so skipping output of namespace state")
+		return b.String()
+	}
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to list deployments in namespace %s: %s\n", namespace, err.Error()))
+	} else {
+		b.WriteString(fmt.Sprintf("\nDeployments currently in namespace %s: %d\n", namespace, len(deployments.Items)))
+		for i := range deployments.Items {
+			dep := &deployments.Items[i]
+			b.WriteString(fmt.Sprintf("  %s: replicas=%d ready=%d available=%d\n", dep.Name, dep.Status.Replicas, dep.Status.ReadyReplicas, dep.Status.AvailableReplicas))
+		}
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("failed to list pods in namespace %s: %s\n", namespace, err.Error()))
+	} else {
+		b.WriteString(fmt.Sprintf("Pods currently in namespace %s: %d\n", namespace, len(pods.Items)))
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			b.WriteString(fmt.Sprintf("  %s: phase=%s\n", pod.Name, pod.Status.Phase))
+			for _, cs := range pod.Status.ContainerStatuses {
+				if w := cs.State.Waiting; w != nil {
+					b.WriteString(fmt.Sprintf("    container %s waiting: reason=%q message=%q\n", cs.Name, w.Reason, w.Message))
+				}
+			}
+		}
+	}
+	return b.String()
 }
 
 // DescribeFailedDeployment returns detailed output to help debug a deployment failure in e2e.
@@ -138,6 +178,105 @@ func DescribeFailedDeployment(ctx context.Context, input WaitForDeploymentsAvail
 		namespace, name))
 	b.WriteString(fmt.Sprintf("\nDeployment:\n%s\n", prettyPrint(input.Deployment)))
 	b.WriteString(describeEvents(ctx, input.Clientset, namespace, name))
+	b.WriteString(describeDeploymentPods(ctx, input.Clientset, input.Deployment))
+	b.WriteString(describeEnvFromConfigMaps(ctx, input.Clientset, input.Deployment))
+	return b.String()
+}
+
+// describeEnvFromConfigMaps returns a string summarizing the keys of any ConfigMaps referenced via
+// envFrom by the deployment's containers. This surfaces misconfigured env sources such as the
+// tigera-operator "kubernetes-services-endpoint" ConfigMap being populated with "<no value>" when
+// the Helm chart is rendered before the cluster controlPlaneEndpoint is set.
+//
+// To avoid leaking private configuration or mistakenly stored credentials into test failure output,
+// only each key's state is reported ("empty", "<no value>" or "set") and never the actual value.
+// Secret envFrom sources are not inspected at all.
+func describeEnvFromConfigMaps(ctx context.Context, clientset *kubernetes.Clientset, deployment *appsv1.Deployment) string {
+	b := strings.Builder{}
+	if clientset == nil {
+		return b.String()
+	}
+	namespace := deployment.GetNamespace()
+	seen := map[string]bool{}
+	containers := append([]corev1.Container{}, deployment.Spec.Template.Spec.InitContainers...)
+	containers = append(containers, deployment.Spec.Template.Spec.Containers...)
+	for _, c := range containers {
+		for _, ef := range c.EnvFrom {
+			if ef.ConfigMapRef == nil || seen[ef.ConfigMapRef.Name] {
+				continue
+			}
+			seen[ef.ConfigMapRef.Name] = true
+			name := ef.ConfigMapRef.Name
+			cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				b.WriteString(fmt.Sprintf("\nenvFrom ConfigMap %s/%s: failed to get: %s\n", namespace, name, err.Error()))
+				continue
+			}
+			b.WriteString(fmt.Sprintf("\nenvFrom ConfigMap %s/%s keys:\n", namespace, name))
+			for k, v := range cm.Data {
+				b.WriteString(fmt.Sprintf("  %s: %s\n", k, envValueState(v)))
+			}
+		}
+	}
+	return b.String()
+}
+
+// envValueState reports the state of an env value without exposing the value itself, so that private
+// configuration or credentials are not copied into test failure output. It distinguishes the
+// "<no value>" placeholder (baked in by a Helm render before its templated source was populated) and
+// empty values from any other set value.
+func envValueState(v string) string {
+	switch v {
+	case "":
+		return "empty"
+	case "<no value>":
+		return "<no value>"
+	default:
+		return "set"
+	}
+}
+
+// describeDeploymentPods returns a string summarizing the pods owned by the given deployment,
+// including their phase, container statuses (e.g. ImagePullBackOff, CrashLoopBackOff) and related
+// events. This helps debug why a deployment never becomes available.
+func describeDeploymentPods(ctx context.Context, clientset *kubernetes.Clientset, deployment *appsv1.Deployment) string {
+	b := strings.Builder{}
+	if clientset == nil {
+		b.WriteString("clientset is nil, so skipping output of deployment pods")
+		return b.String()
+	}
+	namespace := deployment.GetNamespace()
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to build pod selector for deployment %s/%s: %s\n", namespace, deployment.GetName(), err.Error()))
+		return b.String()
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to list pods for deployment %s/%s: %s\n", namespace, deployment.GetName(), err.Error()))
+		return b.String()
+	}
+	b.WriteString(fmt.Sprintf("\nPods for deployment %s/%s (matching %q):\n", namespace, deployment.GetName(), selector.String()))
+	if len(pods.Items) == 0 {
+		b.WriteString("no pods found\n")
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		b.WriteString(fmt.Sprintf("\nPod %s/%s: phase=%s node=%q\n", pod.Namespace, pod.Name, pod.Status.Phase, pod.Spec.NodeName))
+		for _, cond := range pod.Status.Conditions {
+			b.WriteString(fmt.Sprintf("  condition %s=%s reason=%q message=%q\n", cond.Type, cond.Status, cond.Reason, cond.Message))
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			b.WriteString(fmt.Sprintf("  container %s: ready=%t restartCount=%d\n", cs.Name, cs.Ready, cs.RestartCount))
+			if w := cs.State.Waiting; w != nil {
+				b.WriteString(fmt.Sprintf("    waiting: reason=%q message=%q\n", w.Reason, w.Message))
+			}
+			if t := cs.State.Terminated; t != nil {
+				b.WriteString(fmt.Sprintf("    terminated: reason=%q exitCode=%d message=%q\n", t.Reason, t.ExitCode, t.Message))
+			}
+		}
+		b.WriteString(describeEvents(ctx, clientset, pod.Namespace, pod.Name))
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
## Upstream Sync — 2026-08-24

Applied **1/1** commits from [kubernetes-sigs/cluster-api-provider-azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure) `release-1.22` into `backplane-2.17`.

### Applied

- `68e07b65` Merge pull request #6494 from invidian/tigera-operator-debug

