### PR TITLE
Switch Dockerfile.stolostron to PQC-enabled base images (cherry-pick)

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:9.8-1787080706@sha256:71e89a1a51ab32cc30634d89ee4dc8ea40ad9991057fa1eae3b1af32bc7db73f AS toolchain
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS toolchain
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o ./manager .
 
 # Copy the aso-controller into a thin image
-FROM registry.access.redhat.com/ubi9/ubi:9.8-1786985871@sha256:5426a8f45e80a07168a30ea24d84f266094b3756624a5508cc53927e6ee39e09
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8-1787695851
 COPY --from=builder /workspace/manager /manager
 USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/stolostron/cluster-api-provider-azure/pull/433 from `release-1.26` into `main`.

- Switch build-stage base image to `brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26`
- Switch final-stage base image to `registry.redhat.io/ubi9/ubi-minimal-pqc:9.8-1787695851`
- Aligns with ACM 5.0 / MCE 5.0 PQC requirement ([OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113))

Jira: https://redhat.atlassian.net/browse/ACM-41681

## Test plan

- [ ] Build succeeds with new base images
- [ ] Regular mode — no regression
- [ ] FIPS mode — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OCPSTRAT-3113]: https://redhat.atlassian.net/browse/OCPSTRAT-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ