### PR TITLE
Release v1.23.3-hcpclusters.1

### DIFF
--- a/CHANGELOG/v1.23.3-hcpclusters.1.md
+++ b/CHANGELOG/v1.23.3-hcpclusters.1.md
@@ -1,0 +1,23 @@
+## Changes by Kind
+
+### Feature
+
+- **ARO-HCP Support**: Comprehensive ARO Hosted Control Plane support using Azure Service Operator
+  - CRDs: AROCluster, AROControlPlane, and AROMachinePool for managing ARO-HCP clusters
+  - ASO-based resource management for HcpOpenShiftClusters, HcpOpenShiftClustersNodePools, and HcpOpenShiftClustersExternalAuth
+  - Support for `v1api20240610preview` and `v1api20251223preview` API versions
+  - Add MCE version to CAPZ User-Agent header (ARO-24154)
+
+### Security
+
+- Update cel-go to v0.29.0 (GHSA-gcjh-h69q-9w9g)
+- Pin google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf)
+- Update golang.org/x/net and x/text to resolve CVEs (ARO-28528)
+
+## Details
+
+This release is based on upstream v1.23.3 with ARO-HCP support.
+
+Base upstream version: v1.23.3
+ASO version: v2.13
+ARM API version: 2025-12-23-preview


### PR DESCRIPTION
## Summary

- Add CHANGELOG for `v1.23.3-hcpclusters.1` release
- This triggers the release workflow to tag `v1.23.3-hcpclusters.1` on the `release-1.23` branch

ARO-HCP support release based on upstream v1.23.3 with ASO v2.13 (ARM API: 2025-12-23-preview).