### PR TITLE
Release v1.26.0-hcpclusters.1

### DIFF
--- a/CHANGELOG/v1.26.0-hcpclusters.1.md
+++ b/CHANGELOG/v1.26.0-hcpclusters.1.md
@@ -1,0 +1,30 @@
+# v1.26.0-hcpclusters.1
+
+## Changes by Kind
+
+### Feature
+
+- **ARO-HCP Support**: Comprehensive ARO Hosted Control Plane support using Azure Service Operator
+  - CRDs: AROCluster, AROControlPlane, and AROMachinePool for managing ARO-HCP clusters
+  - ASO-based resource management for HcpOpenShiftClusters, HcpOpenShiftClustersNodePools, and HcpOpenShiftClustersExternalAuth
+  - Support for `v1api20251223preview` and `v1api20260630preview` API versions
+  - Bump ARO-HCP API: remove `2024-*-preview`, add `2026-06-30-preview`
+  - Add MCE version to CAPZ User-Agent header (ARO-24154)
+
+### Bug Fixes
+
+- Delete ASO resources by depth to avoid Azure ordering conflicts
+- Switch Dockerfile.stolostron to PQC-enabled base images (ACM-41681)
+
+### Security
+
+- Bump x/text and cel-go for security fixes
+- Pin google.golang.org/grpc to v1.82.1
+
+## Details
+
+This release is based on upstream v1.26.0 with ARO-HCP support.
+
+Base upstream version: v1.26.0
+ASO version: v2.18+
+ARM API versions: 2025-12-23-preview, 2026-06-30-preview


### PR DESCRIPTION
## Summary

- Add CHANGELOG for `v1.26.0-hcpclusters.1` release
- This triggers the release workflow to tag `v1.26.0-hcpclusters.1` on the `release-1.26` branch

ARO-HCP support release based on upstream v1.26.0 with ASO v2.18+ (ARM API: 2026-06-30-preview).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for ARO Hosted Control Plane deployments on Azure.
  - Added APIs for managing hosted clusters, control planes, and machine pools.
  - Updated API versions for improved compatibility.

- **Bug Fixes**
  - Improved resource deletion ordering for more reliable cleanup.
  - Updated container base images.

- **Security**
  - Updated security-related dependencies.

- **Documentation**
  - Added release documentation for version 1.26.0-hcpclusters.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->