### PR TITLE
Add identifying tags to CAPZ-managed ARO-HCP Azure resources (ARO-28913)

### DIFF
--- a/exp/controllers/arocontrolplane_reconciler.go
+++ b/exp/controllers/arocontrolplane_reconciler.go
@@ -429,6 +429,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 		s.scope.ControlPlane.Spec.Resources,
 		mutators.SetHcpOpenShiftClusterDefaults(s.kubeclient, s.scope.ControlPlane, s.scope.Cluster),
 		mutators.SetHcpOpenShiftClusterEncryptionKey(s.scope),
+		mutators.SetResourceTags(s.scope.Cluster.Name, s.scope.ControlPlane.CreationTimestamp.Time),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to apply mutators")

--- a/exp/controllers/aromachinepool_reconciler.go
+++ b/exp/controllers/aromachinepool_reconciler.go
@@ -117,6 +117,7 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 		ctx,
 		s.scope.InfraMachinePool.Spec.Resources,
 		mutators.SetHcpOpenShiftNodePoolDefaults(s.kubeclient, s.scope.InfraMachinePool, hcpClusterName, s.scope.MachinePool),
+		mutators.SetResourceTags(s.scope.ClusterName(), s.scope.InfraMachinePool.CreationTimestamp.Time),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to apply mutators")

--- a/pkg/mutators/resource_tags.go
+++ b/pkg/mutators/resource_tags.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20260630preview"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+)
+
+const (
+	tagCreatedBy = "createdBy"
+	tagCreatedAt = "createdAt"
+
+	tagCreatedByValue = "cluster-api-provider-azure"
+)
+
+// SetResourceTags sets default CAPZ tags on HcpOpenShiftCluster and HcpOpenShiftClustersNodePool resources.
+// Default tags are only added if not already present, so user-defined tags take precedence.
+// The createdAt timestamp uses the owning CAPI object's creation time to remain stable across reconciliations.
+func SetResourceTags(clusterName string, createdAt time.Time) ResourcesMutator {
+	return func(ctx context.Context, us []*unstructured.Unstructured) error {
+		_, log, done := tele.StartSpanWithLogger(ctx, "mutators.SetResourceTags")
+		defer done()
+
+		for i, u := range us {
+			if u.GroupVersionKind().Group != asoredhatopenshiftv1api2026.GroupVersion.Group {
+				continue
+			}
+			kind := u.GroupVersionKind().Kind
+			if kind != scope.HcpClusterKindName && kind != scope.HcpNodePoolKindName {
+				continue
+			}
+
+			resourcePath := fmt.Sprintf("spec.resources[%d]", i)
+			if err := setDefaultTags(u, clusterName, createdAt, resourcePath, log); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func setDefaultTags(resource *unstructured.Unstructured, clusterName string, createdAt time.Time, resourcePath string, log logr.Logger) error {
+	tagsPath := []string{"spec", "tags"}
+
+	existingTags, _, err := unstructured.NestedStringMap(resource.UnstructuredContent(), tagsPath...)
+	if err != nil {
+		return err
+	}
+	if existingTags == nil {
+		existingTags = make(map[string]string)
+	}
+
+	defaultTags := map[string]string{
+		tagCreatedBy:                       tagCreatedByValue,
+		tagCreatedAt:                       createdAt.UTC().Format(time.RFC3339),
+		infrav1.ClusterTagKey(clusterName): string(infrav1.ResourceLifecycleOwned),
+	}
+
+	mutated := false
+	for key, val := range defaultTags {
+		if _, exists := existingTags[key]; !exists {
+			existingTags[key] = val
+			logMutation(log, mutation{
+				location: resourcePath + ".spec.tags." + key,
+				val:      val,
+				reason:   "because CAPZ default tags should be present on managed resources",
+			})
+			mutated = true
+		}
+	}
+
+	if !mutated {
+		return nil
+	}
+
+	tagsInterface := make(map[string]interface{}, len(existingTags))
+	for k, v := range existingTags {
+		tagsInterface[k] = v
+	}
+
+	return unstructured.SetNestedField(resource.UnstructuredContent(), tagsInterface, tagsPath...)
+}

--- a/pkg/mutators/resource_tags_test.go
+++ b/pkg/mutators/resource_tags_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"testing"
+	"time"
+
+	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20260630preview"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
+)
+
+func hcpClusterUnstructured(tags map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": asoredhatopenshiftv1api2026.GroupVersion.String(),
+			"kind":       scope.HcpClusterKindName,
+			"metadata": map[string]interface{}{
+				"name": "test-hcp-cluster",
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+	if tags != nil {
+		u.Object["spec"].(map[string]interface{})["tags"] = tags
+	}
+	return u
+}
+
+func nodePoolUnstructured(tags map[string]interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": asoredhatopenshiftv1api2026.GroupVersion.String(),
+			"kind":       scope.HcpNodePoolKindName,
+			"metadata": map[string]interface{}{
+				"name": "test-nodepool",
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+	if tags != nil {
+		u.Object["spec"].(map[string]interface{})["tags"] = tags
+	}
+	return u
+}
+
+func TestSetResourceTags(t *testing.T) {
+	createdAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	clusterName := "my-cluster"
+	ownershipTagKey := infrav1.ClusterTagKey(clusterName)
+
+	tests := []struct {
+		name         string
+		resources    []*unstructured.Unstructured
+		validateTags func(*WithT, []*unstructured.Unstructured)
+	}{
+		{
+			name: "sets all default tags on HcpOpenShiftCluster",
+			resources: []*unstructured.Unstructured{
+				hcpClusterUnstructured(nil),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				tags, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedBy, tagCreatedByValue))
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2026-07-30T12:00:00Z"))
+				g.Expect(tags).To(HaveKeyWithValue(ownershipTagKey, string(infrav1.ResourceLifecycleOwned)))
+			},
+		},
+		{
+			name: "sets all default tags on HcpOpenShiftClustersNodePool",
+			resources: []*unstructured.Unstructured{
+				nodePoolUnstructured(nil),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				tags, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedBy, tagCreatedByValue))
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2026-07-30T12:00:00Z"))
+				g.Expect(tags).To(HaveKeyWithValue(ownershipTagKey, string(infrav1.ResourceLifecycleOwned)))
+			},
+		},
+		{
+			name: "preserves user-defined tags",
+			resources: []*unstructured.Unstructured{
+				hcpClusterUnstructured(map[string]interface{}{
+					"environment": "production",
+					"team":        "sre",
+				}),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				tags, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(tags).To(HaveKeyWithValue("environment", "production"))
+				g.Expect(tags).To(HaveKeyWithValue("team", "sre"))
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedBy, tagCreatedByValue))
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2026-07-30T12:00:00Z"))
+				g.Expect(tags).To(HaveKeyWithValue(ownershipTagKey, string(infrav1.ResourceLifecycleOwned)))
+			},
+		},
+		{
+			name: "user-defined tags take precedence over defaults",
+			resources: []*unstructured.Unstructured{
+				hcpClusterUnstructured(map[string]interface{}{
+					tagCreatedBy: "my-custom-tool",
+				}),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				tags, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedBy, "my-custom-tool"))
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2026-07-30T12:00:00Z"))
+				g.Expect(tags).To(HaveKeyWithValue(ownershipTagKey, string(infrav1.ResourceLifecycleOwned)))
+			},
+		},
+		{
+			name: "createdAt is immutable when already set",
+			resources: []*unstructured.Unstructured{
+				hcpClusterUnstructured(map[string]interface{}{
+					tagCreatedAt: "2025-01-01T00:00:00Z",
+				}),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				tags, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeTrue())
+				g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2025-01-01T00:00:00Z"))
+			},
+		},
+		{
+			name: "skips non-ARO resources",
+			resources: []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "containerservice.azure.com/v1api20231001",
+						"kind":       "ManagedCluster",
+						"metadata": map[string]interface{}{
+							"name": "aks-cluster",
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				_, found, err := unstructured.NestedStringMap(us[0].UnstructuredContent(), "spec", "tags")
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(found).To(BeFalse())
+			},
+		},
+		{
+			name: "handles multiple resources",
+			resources: []*unstructured.Unstructured{
+				hcpClusterUnstructured(nil),
+				nodePoolUnstructured(nil),
+			},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				for _, u := range us {
+					tags, found, err := unstructured.NestedStringMap(u.UnstructuredContent(), "spec", "tags")
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(found).To(BeTrue())
+					g.Expect(tags).To(HaveKeyWithValue(tagCreatedBy, tagCreatedByValue))
+					g.Expect(tags).To(HaveKeyWithValue(tagCreatedAt, "2026-07-30T12:00:00Z"))
+					g.Expect(tags).To(HaveKeyWithValue(ownershipTagKey, string(infrav1.ResourceLifecycleOwned)))
+				}
+			},
+		},
+		{
+			name:      "handles empty resources list",
+			resources: []*unstructured.Unstructured{},
+			validateTags: func(g *WithT, us []*unstructured.Unstructured) {
+				g.Expect(us).To(BeEmpty())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mutator := SetResourceTags(clusterName, createdAt)
+			err := mutator(t.Context(), test.resources)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			test.validateTags(g, test.resources)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new `SetResourceTags` mutator that injects default CAPZ tags (`createdBy`, `createdAt`, ownership) on `HcpOpenShiftCluster` and `HcpOpenShiftClustersNodePool` ASO resources
- Wire the mutator into both `arocontrolplane_reconciler` and `aromachinepool_reconciler`
- User-defined tags always take precedence; `createdAt` is immutable after first creation

Enables SRE to identify CAPZ-created resources in ARM for runbooks, leak tracking, and metrics correlation.

Jira: https://issues.redhat.com/browse/ARO-28913

## Test plan
- [x] Unit tests for `SetResourceTags` mutator (8 test cases covering all acceptance criteria)
- [ ] Verify tags are visible in ARM / Azure Portal on provisioned HcpOpenShiftCluster
- [ ] Verify tags are visible in ARM / Azure Portal on provisioned HcpOpenShiftClustersNodePool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically applying default metadata tags to ARO-HCP cluster and node pool resources.
  * Preserves existing user-defined tags and prevents overwriting existing creation timestamps.
  * Supports ownership and creation details for improved resource tracking.

* **Documentation**
  * Added release documentation for ARO-HCP support based on upstream v1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->