### PR TITLE
Fix ARO imports for v20260901preview

### DIFF
--- a/exp/controllers/arocontrolplane_reconciler_test.go
+++ b/exp/controllers/arocontrolplane_reconciler_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	asoredhatopenshiftv1hub "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview/storage"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -82,7 +82,7 @@ func createTestScopeWithOptions(t *testing.T, kubeconfigData *string, createKube
 	_ = cplane.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = asoredhatopenshiftv1hub.AddToScheme(scheme)
-	_ = asoredhatopenshiftv1api2026.AddToScheme(scheme)
+	_ = asoredhatopenshiftv2026.AddToScheme(scheme)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ import (
 	asomanagedidentityv1api20230131 "github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20230131"
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	asoredhatopenshiftv1hub "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview/storage"
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	"github.com/spf13/pflag"
@@ -100,7 +100,7 @@ func init() {
 	_ = asokeyvaultv1.AddToScheme(scheme)
 	_ = asokubernetesconfigurationv1.AddToScheme(scheme)
 	_ = asomanagedidentityv1api20230131.AddToScheme(scheme)
-	_ = asoredhatopenshiftv1api2026.AddToScheme(scheme)
+	_ = asoredhatopenshiftv2026.AddToScheme(scheme)
 	_ = asoredhatopenshiftv1hub.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }

--- a/pkg/mutators/arocontrolplane.go
+++ b/pkg/mutators/arocontrolplane.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -41,7 +41,7 @@ var (
 	ErrNoAROClusterDefined = fmt.Errorf("no %s AROCluster defined in AROControlPlane spec.resources", infrav1exp.GroupVersion.Group)
 
 	// ErrNoHcpOpenShiftClusterDefined describes an AROControlPlane without a HcpOpenShiftCluster.
-	ErrNoHcpOpenShiftClusterDefined = fmt.Errorf("no %s HcpOpenShiftCluster defined in AROControlPlane spec.resources", asoredhatopenshiftv1api2026.GroupVersion.Group)
+	ErrNoHcpOpenShiftClusterDefined = fmt.Errorf("no %s HcpOpenShiftCluster defined in AROControlPlane spec.resources", asoredhatopenshiftv2026.GroupVersion.Group)
 )
 
 // SetAROClusterDefaults propagates values defined by Cluster API to an ARO AROCluster.
@@ -202,7 +202,7 @@ func SetHcpOpenShiftClusterDefaults(_ client.Client, _ *controlv1.AROControlPlan
 		var hcpClusterPath string
 		var hcpClusterName string
 		for i, u := range us {
-			if u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group &&
+			if u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group &&
 				u.GroupVersionKind().Kind == scope.HcpClusterKindName {
 				hcpCluster = u
 				hcpClusterName = u.GetName()
@@ -221,7 +221,7 @@ func SetHcpOpenShiftClusterDefaults(_ client.Client, _ *controlv1.AROControlPlan
 
 		// Set owner references for HcpOpenShiftClustersExternalAuth resources
 		for i, u := range us {
-			if u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group &&
+			if u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group &&
 				u.GroupVersionKind().Kind == "HcpOpenShiftClustersExternalAuth" {
 				if err := setExternalAuthOwner(ctx, u, hcpClusterName, fmt.Sprintf("spec.resources[%d]", i), log); err != nil {
 					return err
@@ -244,7 +244,7 @@ func SetHcpOpenShiftClusterEncryptionKey(vaultInfoProvider VaultInfoProvider) Re
 		var hcpCluster *unstructured.Unstructured
 		var hcpClusterPath string
 		for i, u := range us {
-			if u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group &&
+			if u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group &&
 				u.GroupVersionKind().Kind == scope.HcpClusterKindName {
 				hcpCluster = u
 				hcpClusterPath = fmt.Sprintf("spec.resources[%d]", i)

--- a/pkg/mutators/aromachinepool.go
+++ b/pkg/mutators/aromachinepool.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -34,7 +34,7 @@ import (
 
 var (
 	// ErrNoHcpOpenShiftClustersNodePoolDefined describes an AROMachinePool without a HcpOpenShiftClustersNodePool.
-	ErrNoHcpOpenShiftClustersNodePoolDefined = fmt.Errorf("no %s HcpOpenShiftClustersNodePool defined in AROMachinePool spec.resources", asoredhatopenshiftv1api2026.GroupVersion.Group)
+	ErrNoHcpOpenShiftClustersNodePoolDefined = fmt.Errorf("no %s HcpOpenShiftClustersNodePool defined in AROMachinePool spec.resources", asoredhatopenshiftv2026.GroupVersion.Group)
 )
 
 // SetHcpOpenShiftNodePoolDefaults sets defaults for HcpOpenShiftClustersNodePool resources.
@@ -49,7 +49,7 @@ func SetHcpOpenShiftNodePoolDefaults(_ client.Client, _ *infrav1exp.AROMachinePo
 		var nodePool *unstructured.Unstructured
 		var nodePoolPath string
 		for i, u := range us {
-			if u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group &&
+			if u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group &&
 				u.GroupVersionKind().Kind == scope.HcpNodePoolKindName {
 				nodePool = u
 				nodePoolPath = fmt.Sprintf("spec.resources[%d]", i)

--- a/pkg/mutators/aromachinepool_test.go
+++ b/pkg/mutators/aromachinepool_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,7 +194,7 @@ func TestReconcileAROAutoscaling(t *testing.T) {
 
 			// Create HcpOpenShiftClustersNodePool with autoscaling config
 			nodePool := &unstructured.Unstructured{}
-			nodePool.SetGroupVersionKind(asoredhatopenshiftv1api2026.GroupVersion.WithKind("HcpOpenShiftClustersNodePool"))
+			nodePool.SetGroupVersionKind(asoredhatopenshiftv2026.GroupVersion.WithKind("HcpOpenShiftClustersNodePool"))
 
 			if test.autoScaling != nil {
 				err := unstructured.SetNestedMap(nodePool.UnstructuredContent(), test.autoScaling, "spec", "properties", "autoScaling")
@@ -376,7 +376,7 @@ func TestReconcileAROAutoscaling_WithDifferentAutoScalingConfigs(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			nodePool := &unstructured.Unstructured{}
-			nodePool.SetGroupVersionKind(asoredhatopenshiftv1api2026.GroupVersion.WithKind("HcpOpenShiftClustersNodePool"))
+			nodePool.SetGroupVersionKind(asoredhatopenshiftv2026.GroupVersion.WithKind("HcpOpenShiftClustersNodePool"))
 
 			if test.autoScalingField != nil {
 				if asMap, ok := test.autoScalingField.(map[string]interface{}); ok {

--- a/pkg/mutators/resource_tags.go
+++ b/pkg/mutators/resource_tags.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20260630preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -46,7 +46,7 @@ func SetResourceTags(clusterName string, createdAt time.Time) ResourcesMutator {
 		defer done()
 
 		for i, u := range us {
-			if u.GroupVersionKind().Group != asoredhatopenshiftv1api2026.GroupVersion.Group {
+			if u.GroupVersionKind().Group != asoredhatopenshiftv2026.GroupVersion.Group {
 				continue
 			}
 			kind := u.GroupVersionKind().Kind

--- a/pkg/mutators/resource_tags_test.go
+++ b/pkg/mutators/resource_tags_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20260630preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -31,7 +31,7 @@ import (
 func hcpClusterUnstructured(tags map[string]interface{}) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": asoredhatopenshiftv1api2026.GroupVersion.String(),
+			"apiVersion": asoredhatopenshiftv2026.GroupVersion.String(),
 			"kind":       scope.HcpClusterKindName,
 			"metadata": map[string]interface{}{
 				"name": "test-hcp-cluster",
@@ -48,7 +48,7 @@ func hcpClusterUnstructured(tags map[string]interface{}) *unstructured.Unstructu
 func nodePoolUnstructured(tags map[string]interface{}) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": asoredhatopenshiftv1api2026.GroupVersion.String(),
+			"apiVersion": asoredhatopenshiftv2026.GroupVersion.String(),
 			"kind":       scope.HcpNodePoolKindName,
 			"metadata": map[string]interface{}{
 				"name": "test-nodepool",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the resource-tag mutator and its tests from the old `v1api20260630preview` import to `v20260901preview`, completing the ARO API migration. Standardizes the import alias to `asoredhatopenshiftv2026` across the manager, ARO mutators, and related tests.

Jira: [ARO-29438](https://redhat.atlassian.net/browse/ARO-29438)

**Special notes for your reviewer**:

Validation passed:
- `go test ./pkg/mutators`
- `gofmt` check on all changed Go files
- `git diff --check`


**Release note**:

```release-note
Fix the ARO resource-tag mutator to use the v20260901preview ASO API.
```


[ARO-29438]: https://redhat.atlassian.net/browse/ARO-29438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ