### PR TITLE
ARO-29438: [release-1.26] Backport ARO import fixes (#455)

### DIFF
--- a/exp/controllers/arocontrolplane_reconciler.go
+++ b/exp/controllers/arocontrolplane_reconciler.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	asoconditions "github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -302,7 +302,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 		}
 
 		if (u.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			u.GroupVersionKind().Kind == "HcpOpenShiftCluster" {
 			// Check if etcd.dataEncryption.customerManaged.kms is configured
 			etcdPath := []string{"spec", "properties", "etcd", "dataEncryption", "customerManaged", "kms"}
@@ -440,7 +440,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 	hasExternalAuthInSpec := false
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == hcpOpenShiftClustersExternalAuthKind {
 			hasExternalAuthInSpec = true
 			break
@@ -484,7 +484,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 	var hcpClusterName string
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == "HcpOpenShiftCluster" {
 			hcpClusterName = resource.GetName()
 			break
@@ -526,7 +526,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 		}
 	} else if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || isSchemeError(err) {
 		// Not found or API version not served, try v20260901preview
-		hcpClusterV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftCluster{}
+		hcpClusterV2 := &asoredhatopenshiftv2026.HcpOpenShiftCluster{}
 		err = s.kubeclient.Get(ctx, client.ObjectKey{
 			Namespace: s.scope.ControlPlane.Namespace,
 			Name:      hcpClusterName,
@@ -633,7 +633,7 @@ func (s *aroControlPlaneService) reconcileResources(ctx context.Context) error {
 	hasExternalAuth := false
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == hcpOpenShiftClustersExternalAuthKind {
 			hasExternalAuth = true
 			break
@@ -661,7 +661,7 @@ func (s *aroControlPlaneService) setExternalAuthCondition(ctx context.Context, r
 	var externalAuthName string
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == hcpOpenShiftClustersExternalAuthKind {
 			externalAuthName = resource.GetName()
 			break
@@ -690,7 +690,7 @@ func (s *aroControlPlaneService) setExternalAuthCondition(ctx context.Context, r
 		externalAuthConditions = externalAuthV1.Status.Conditions
 	} else if client.IgnoreNotFound(err) == nil {
 		// Not found, try v20260901preview
-		externalAuthV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftClustersExternalAuth{}
+		externalAuthV2 := &asoredhatopenshiftv2026.HcpOpenShiftClustersExternalAuth{}
 		err = s.kubeclient.Get(ctx, client.ObjectKey{
 			Namespace: s.scope.ControlPlane.Namespace,
 			Name:      externalAuthName,
@@ -990,7 +990,7 @@ func (s *aroControlPlaneService) filterExternalAuthUntilNodePoolReady(ctx contex
 
 	// Check v20260901preview node pools if not already found
 	if !hasReadyNodePool {
-		nodePoolListV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftClustersNodePoolList{}
+		nodePoolListV2 := &asoredhatopenshiftv2026.HcpOpenShiftClustersNodePoolList{}
 		if err := s.kubeclient.List(ctx, nodePoolListV2, client.InNamespace(s.scope.Namespace())); err != nil {
 			// Ignore NotFound, NoMatch, and scheme registration errors (when types not in scheme)
 			if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) && !isSchemeError(err) {
@@ -1026,7 +1026,7 @@ func (s *aroControlPlaneService) filterExternalAuthUntilNodePoolReady(ctx contex
 	filteredCount := 0
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == hcpOpenShiftClustersExternalAuthKind {
 			// Check if this ExternalAuth resource already exists in the cluster
 			existsInCluster := s.externalAuthExists(ctx, resource.GetName())
@@ -1073,7 +1073,7 @@ func (s *aroControlPlaneService) externalAuthExists(ctx context.Context, name st
 
 	// Not found or error, try v20260901preview
 	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || isSchemeError(err) {
-		externalAuthV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftClustersExternalAuth{}
+		externalAuthV2 := &asoredhatopenshiftv2026.HcpOpenShiftClustersExternalAuth{}
 		err = s.kubeclient.Get(ctx, client.ObjectKey{
 			Namespace: s.scope.ControlPlane.Namespace,
 			Name:      name,

--- a/exp/controllers/arocontrolplane_reconciler_test.go
+++ b/exp/controllers/arocontrolplane_reconciler_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -82,7 +82,7 @@ func createTestScopeWithOptions(t *testing.T, kubeconfigData *string, createKube
 	_ = cplane.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = asoredhatopenshiftv1.AddToScheme(scheme)
-	_ = asoredhatopenshiftv1api2026.AddToScheme(scheme)
+	_ = asoredhatopenshiftv2026.AddToScheme(scheme)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/exp/controllers/aromachinepool_providerid_test.go
+++ b/exp/controllers/aromachinepool_providerid_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -488,37 +488,37 @@ func TestProviderIDListSync_BaseDomainPrefixV1api20251223preview(t *testing.T) {
 		Build()
 
 	// Use v20260901preview node pool
-	nodePoolV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftClustersNodePool{
+	nodePoolV2 := &asoredhatopenshiftv2026.HcpOpenShiftClustersNodePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HcpOpenShiftClustersNodePool",
-			APIVersion: asoredhatopenshiftv1api2026.GroupVersion.String(),
+			APIVersion: asoredhatopenshiftv2026.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodePoolName,
 			Namespace: namespace,
 		},
-		Spec: asoredhatopenshiftv1api2026.HcpOpenShiftClustersNodePool_Spec{
+		Spec: asoredhatopenshiftv2026.HcpOpenShiftClustersNodePool_Spec{
 			AzureName: azureName,
 			Owner: &genruntime.KnownResourceReference{
 				Name: clusterName,
 			},
 		},
-		Status: asoredhatopenshiftv1api2026.HcpOpenShiftClustersNodePool_STATUS{
-			Properties: &asoredhatopenshiftv1api2026.NodePoolProperties_STATUS{
+		Status: asoredhatopenshiftv2026.HcpOpenShiftClustersNodePool_STATUS{
+			Properties: &asoredhatopenshiftv2026.NodePoolProperties_STATUS{
 				Replicas: ptr.To(1),
 			},
 		},
 	}
 
 	// Use v20260901preview HcpOpenShiftCluster (NOT v1api20251223preview)
-	hcpClusterV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftCluster{
+	hcpClusterV2 := &asoredhatopenshiftv2026.HcpOpenShiftCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: namespace,
 		},
-		Status: asoredhatopenshiftv1api2026.HcpOpenShiftCluster_STATUS{
-			Properties: &asoredhatopenshiftv1api2026.HcpOpenShiftClusterProperties_STATUS{
-				Dns: &asoredhatopenshiftv1api2026.DnsProfile_STATUS{
+		Status: asoredhatopenshiftv2026.HcpOpenShiftCluster_STATUS{
+			Properties: &asoredhatopenshiftv2026.HcpOpenShiftClusterProperties_STATUS{
+				Dns: &asoredhatopenshiftv2026.DnsProfile_STATUS{
 					BaseDomainPrefix: ptr.To(baseDomainPrefix),
 				},
 			},
@@ -558,7 +558,7 @@ func TestProviderIDListSync_BaseDomainPrefixV1api20251223preview(t *testing.T) {
 	_ = infrav2exp.AddToScheme(mgmtScheme)
 	_ = cplane.AddToScheme(mgmtScheme)
 	_ = clusterv1.AddToScheme(mgmtScheme)
-	_ = asoredhatopenshiftv1api2026.AddToScheme(mgmtScheme)
+	_ = asoredhatopenshiftv2026.AddToScheme(mgmtScheme)
 
 	mgmtClient := fake.NewClientBuilder().
 		WithScheme(mgmtScheme).

--- a/exp/controllers/aromachinepool_reconciler.go
+++ b/exp/controllers/aromachinepool_reconciler.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	asoconditions "github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -134,7 +134,7 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 	var nodePoolName string
 	for _, resource := range resources {
 		if (resource.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-			resource.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+			resource.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 			resource.GroupVersionKind().Kind == "HcpOpenShiftClustersNodePool" {
 			nodePoolName = resource.GetName()
 			break
@@ -176,7 +176,7 @@ func (s *aroMachinePoolService) reconcileResources(ctx context.Context) error {
 		}
 	} else if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || isSchemeError(err) {
 		// Not found, API version not served, or scheme error - try v20260901preview
-		nodePoolV2 := &asoredhatopenshiftv1api2026.HcpOpenShiftClustersNodePool{}
+		nodePoolV2 := &asoredhatopenshiftv2026.HcpOpenShiftClustersNodePool{}
 		err = s.kubeclient.Get(ctx, client.ObjectKey{
 			Namespace: s.scope.InfraMachinePool.Namespace,
 			Name:      nodePoolName,
@@ -480,7 +480,7 @@ func (s *aroMachinePoolService) getBaseDomainPrefix(ctx context.Context) (string
 		return "", errors.Wrap(err, "failed to get HcpOpenShiftCluster (v1api20251223preview)")
 	}
 
-	v2 := &asoredhatopenshiftv1api2026.HcpOpenShiftCluster{}
+	v2 := &asoredhatopenshiftv2026.HcpOpenShiftCluster{}
 	if err := s.kubeclient.Get(ctx, name, v2); err == nil {
 		if v2.Status.Properties != nil && v2.Status.Properties.Dns != nil && v2.Status.Properties.Dns.BaseDomainPrefix != nil {
 			return *v2.Status.Properties.Dns.BaseDomainPrefix, nil

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +102,7 @@ func init() {
 	_ = asokubernetesconfigurationv1.AddToScheme(scheme)
 	_ = asomanagedidentityv1api20230131.AddToScheme(scheme)
 	_ = asoredhatopenshiftv1.AddToScheme(scheme)
-	_ = asoredhatopenshiftv1api2026.AddToScheme(scheme)
+	_ = asoredhatopenshiftv2026.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/mutators/arocontrolplane.go
+++ b/pkg/mutators/arocontrolplane.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -203,7 +203,7 @@ func SetHcpOpenShiftClusterDefaults(_ client.Client, _ *controlv1.AROControlPlan
 		var hcpClusterName string
 		for i, u := range us {
 			if (u.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-				u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+				u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 				u.GroupVersionKind().Kind == "HcpOpenShiftCluster" {
 				hcpCluster = u
 				hcpClusterName = u.GetName()
@@ -223,7 +223,7 @@ func SetHcpOpenShiftClusterDefaults(_ client.Client, _ *controlv1.AROControlPlan
 		// Set owner references for HcpOpenShiftClustersExternalAuth resources
 		for i, u := range us {
 			if (u.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-				u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+				u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 				u.GroupVersionKind().Kind == "HcpOpenShiftClustersExternalAuth" {
 				if err := setExternalAuthOwner(ctx, u, hcpClusterName, fmt.Sprintf("spec.resources[%d]", i), log); err != nil {
 					return err
@@ -247,7 +247,7 @@ func SetHcpOpenShiftClusterEncryptionKey(vaultInfoProvider VaultInfoProvider) Re
 		var hcpClusterPath string
 		for i, u := range us {
 			if (u.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-				u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+				u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 				u.GroupVersionKind().Kind == "HcpOpenShiftCluster" {
 				hcpCluster = u
 				hcpClusterPath = fmt.Sprintf("spec.resources[%d]", i)

--- a/pkg/mutators/aromachinepool.go
+++ b/pkg/mutators/aromachinepool.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	asoredhatopenshiftv1 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v1api20251223preview"
-	asoredhatopenshiftv1api2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
+	asoredhatopenshiftv2026 "github.com/Azure/azure-service-operator/v2/api/redhatopenshift/v20260901preview"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -50,7 +50,7 @@ func SetHcpOpenShiftNodePoolDefaults(_ client.Client, _ *infrav1exp.AROMachinePo
 		var nodePoolPath string
 		for i, u := range us {
 			if (u.GroupVersionKind().Group == asoredhatopenshiftv1.GroupVersion.Group ||
-				u.GroupVersionKind().Group == asoredhatopenshiftv1api2026.GroupVersion.Group) &&
+				u.GroupVersionKind().Group == asoredhatopenshiftv2026.GroupVersion.Group) &&
 				u.GroupVersionKind().Kind == "HcpOpenShiftClustersNodePool" {
 				nodePool = u
 				nodePoolPath = fmt.Sprintf("spec.resources[%d]", i)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Backports the applicable import-alias changes from https://github.com/stolostron/cluster-api-provider-azure/pull/455 to `release-1.26`. Standardizes the `v20260901preview` import alias to `asoredhatopenshiftv2026` across the manager, ARO controllers, mutators, and related tests.

Jira: [ARO-29438](https://redhat.atlassian.net/browse/ARO-29438)

**Special notes for your reviewer**:

Adapted backport using the prepared release-branch changes. The resource-tag mutator updated in #455 is not present on this branch, so that portion does not apply. Existing API import paths remain unchanged.

Validation passed:
- `make lint` (0 issues)
- `make test` (code generation and full Go test suite with race detector)
- `git diff --check`

Code generation produced no additional tracked changes.

**Release note**:

```release-note
NONE
```


[ARO-29438]: https://redhat.atlassian.net/browse/ARO-29438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ