### PR TITLE
Update release-1.26 ASO and CAPZ image references

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -2,9 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 namespace: capz-system
 resources:
-  # The ASO version here is managed by `make generate-aso-crds`
-  - https://github.com/stolostron/azure-service-operator/releases/download/v2.18.0-hcpclusters.2/azureserviceoperator_v2.18.0-hcpclusters.2.yaml
-  - crds.yaml
+  - https://github.com/stolostron/azure-service-operator/releases/download/v2.18.0-hcpclusters.3/azureserviceoperator_v2.18.0-hcpclusters.3.yaml
   - settings.yaml
 patches:
   - path: patches/migrate_stored_versions.yaml
@@ -22,7 +20,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: quay.io/capz/azureserviceoperator:v2.18.0-hcpclusters.1
+        value: quay.io/capz/azureserviceoperator:v2.18.0-hcpclusters.3
       - op: replace
         path: /spec/replicas
         value: 1
@@ -49,7 +47,13 @@ patches:
       # manages. The migrate-aso-crd-stored-versions init container deletes
       # CRDs that have stale entries in status.storedVersions which the new
       # bundle no longer lists in spec.versions; the new ASO controller then
-      # re-creates them from its bundled definitions.
+      # re-creates them from its bundled definitions. Without this verb the
+      # init container's CRD delete is denied. The upstream ASO
+      # azureserviceoperator-crd-manager-role grants
+      # [create get list patch update watch] on customresourcedefinitions
+      # cluster-wide; we add delete as a separate rule scoped via resourceNames
+      # to just the CAPZ-managed CRDs, so a compromised ASO pod can't delete
+      # arbitrary CRDs in the cluster.
       - op: test
         path: /rules/0/resources/0
         value: customresourcedefinitions

--- a/config/capz/manager_image_patch.yaml
+++ b/config/capz/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:main
+      - image: quay.io/capz/cluster-api-provider-azure-rhel9:v1.26.0-hcpclusters.1
         name: manager


### PR DESCRIPTION
Updates the release-1.26 Kustomize inputs for the next infrastructure-components.yaml release.

Changes:
- use ASO v2.18.0-hcpclusters.3 resources and image
- use quay.io/capz/cluster-api-provider-azure-rhel9:v1.26.0-hcpclusters.1 for the CAPZ manager
- ensure the existing Kustomize replacement propagates the CAPZ image to migrate-aso-crd-stored-versions