### PR TITLE
Update references in the release infrastructure-components.yaml

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: quay.io/capz/azureserviceoperator:stolostron
+        value: quay.io/capz/azure-service-operator-rhel9:stolostron
       - op: replace
         path: /spec/replicas
         value: 1

--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: quay.io/capz/azureserviceoperator:v2.20.0-hcpclusters.1
+        value: quay.io/capz/azureserviceoperator:stolostron
       - op: replace
         path: /spec/replicas
         value: 1

--- a/config/capz/manager_image_patch.yaml
+++ b/config/capz/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:main
+      - image: quay.io/capz/cluster-api-provider-azure-rhel9:stolostron
         name: manager


### PR DESCRIPTION
Cherry-pick of #458 onto stolostron/main.

This applies the current state of the infrastructure-components-main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Azure Service Operator controller image used during deployment.
  - Updated the Cluster API Provider Azure manager image used during deployment.
  - No other component behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->