### PR TITLE
Fix ASO image repository for release-1.26

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: quay.io/capz/azureserviceoperator:v2.18.0-hcpclusters.3
+        value: quay.io/capz/azure-service-operator-rhel9:v2.18.0-hcpclusters.3
       - op: replace
         path: /spec/replicas
         value: 1


### PR DESCRIPTION
Update the Azure Service Operator image repository from quay.io/capz/azureserviceoperator to quay.io/capz/azure-service-operator-rhel9 while preserving the existing v2.18.0-hcpclusters.3 tag.